### PR TITLE
Fix Resting HR display

### DIFF
--- a/frontend/src/AjoDashboard.jsx
+++ b/frontend/src/AjoDashboard.jsx
@@ -12,12 +12,14 @@ export default function AjoDashboard() {
 
   if (!summary) return <p>Loading...</p>;
 
+  const restingHrValue = summary.resting_hr ?? summary.restingHr;
+
   return (
     <div className="p-6 font-sans">
       <h1 className="text-2xl font-bold mb-4">Andy’s Garmin Summary</h1>
       <ul className="space-y-2">
         <li>Steps: {summary.steps}</li>
-        <li>Resting HR: {summary.restingHr}</li>
+        <li>Resting HR: {restingHrValue ? restingHrValue : 'N/A'}</li>
         <li>VO2 Max: {summary.vo2max}</li>
         <li>Sleep Hours: {summary.sleep_hours}</li>
       </ul>


### PR DESCRIPTION
## Summary
- show `resting_hr` from `/api/summary`
- handle missing or falsy `resting_hr` values

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687eda2b9f288324b5354feea9a2016f