### PR TITLE
Add live InfluxDB query to API

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,33 +1,23 @@
 const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
+const { fetchGarminSummary } = require('./influx');
 
+dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3001;
 
 app.use(cors());
 
-app.get('/api/summary', (req, res) => {
-  res.json({
-    steps: 8430,
-    resting_hr: 52,
-    vo2max: 47.1,
-    sleep_hours: 7.4,
-    stepsChart: {
-      labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
-      datasets: [
-        {
-          label: 'Steps',
-          data: [7800, 8200, 8600, 9000, 8800, 10200, 8430],
-          fill: true,
-          backgroundColor: 'rgba(0, 123, 255, 0.1)',
-          borderColor: 'rgba(0, 123, 255, 1)',
-          tension: 0.3
-        }
-      ]
-    }
-  });
+app.get('/api/summary', async (req, res) => {
+  try {
+    const data = await fetchGarminSummary();
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch data from InfluxDB' });
+  }
 });
 
 app.listen(PORT, () => {

--- a/api/influx.js
+++ b/api/influx.js
@@ -1,23 +1,59 @@
-import { InfluxDB, Point } from '@influxdata/influxdb-client'
-import dotenv from 'dotenv'
-dotenv.config()
+const { InfluxDB, Point } = require('@influxdata/influxdb-client');
+const dotenv = require('dotenv');
+dotenv.config();
 
-const url = process.env.INFLUX_URL
-const token = process.env.INFLUX_TOKEN
-const org = process.env.INFLUX_ORG
-const bucket = process.env.INFLUX_BUCKET
+const token = process.env.INFLUX_TOKEN;
+const org = process.env.INFLUX_ORG;
+const bucket = process.env.INFLUX_BUCKET;
 
-const client = new InfluxDB({ url, token })
-const writeApi = client.getWriteApi(org, bucket, 'ns')
-writeApi.useDefaultTags({ host: 'host1' })
+const client = new InfluxDB({ url: process.env.INFLUX_URL, token });
 
-export function writeGarminSummary({ steps, vo2max, resting_hr, sleep_hours }) {
+const writeApi = client.getWriteApi(org, bucket, 'ns');
+writeApi.useDefaultTags({ host: 'host1' });
+
+function writeGarminSummary({ steps, vo2max, resting_hr, sleep_hours }) {
   const point = new Point('daily_summary')
     .intField('steps', steps)
     .intField('vo2max', vo2max)
     .intField('resting_hr', resting_hr)
-    .floatField('sleep_hours', sleep_hours)
+    .floatField('sleep_hours', sleep_hours);
 
-  writeApi.writePoint(point)
-  return writeApi.flush()
+  writeApi.writePoint(point);
+  return writeApi.flush();
 }
+
+const queryApi = client.getQueryApi(org);
+
+async function fetchGarminSummary() {
+  const query = `
+    from(bucket: "${bucket}")
+      |> range(start: -1d)
+      |> filter(fn: (r) => r._measurement == "garmin")
+      |> filter(fn: (r) => r._field == "steps" or r._field == "resting_hr" or r._field == "vo2max" or r._field == "sleep_hours")
+      |> last()
+  `;
+
+  const summary = {
+    steps: null,
+    resting_hr: null,
+    vo2max: null,
+    sleep_hours: null,
+  };
+
+  await queryApi.collectRows(query, {
+    next(row, tableMeta) {
+      const o = tableMeta.toObject(row);
+      summary[o._field] = o._value;
+    },
+    error(error) {
+      console.error('Query error', error);
+    },
+    complete() {
+      console.log('Query complete');
+    },
+  });
+
+  return summary;
+}
+
+module.exports = { writeGarminSummary, fetchGarminSummary };


### PR DESCRIPTION
## Summary
- hook up backend to InfluxDB
- expose `/api/summary` using live database values

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687edf5bf5188324929a2004922c482b