### PR TITLE
Implement live Garmin summary API

### DIFF
--- a/api/importGarmin.js
+++ b/api/importGarmin.js
@@ -1,21 +1,70 @@
-import fs from 'fs'
-import path from 'path'
-import { writeGarminSummary } from './influx.js'
+const { InfluxDB } = require('@influxdata/influxdb-client');
 
-const filePath = process.argv[2]
-if (!filePath) {
-  console.error('Usage: node importGarmin.js <path-to-json>')
-  process.exit(1)
+const url = process.env.INFLUX_URL;
+const token = process.env.INFLUX_TOKEN;
+const org = process.env.INFLUX_ORG;
+const bucket = process.env.INFLUX_BUCKET;
+
+const client = new InfluxDB({ url, token });
+const queryApi = client.getQueryApi(org);
+
+function fetchGarminSummary() {
+  return new Promise((resolve, reject) => {
+    const query = `
+      from(bucket: "${bucket}")
+        |> range(start: -1d)
+        |> filter(fn: (r) => r._measurement == "garmin_daily")
+    `;
+
+    const summary = {
+      steps: 0,
+      resting_hr: 0,
+      vo2max: 0,
+      sleep_hours: 0,
+      stepsChart: {
+        labels: [],
+        datasets: [
+          {
+            label: 'Steps',
+            data: [],
+            fill: true,
+            backgroundColor: 'rgba(0, 123, 255, 0.1)',
+            borderColor: 'rgba(0, 123, 255, 1)',
+            tension: 0.3
+          }
+        ]
+      }
+    };
+
+    queryApi.queryRows(query, {
+      next(row, tableMeta) {
+        const o = tableMeta.toObject(row);
+        const t = new Date(o._time).toLocaleDateString('en-US', { weekday: 'short' });
+        switch (o._field) {
+          case 'steps':
+            summary.stepsChart.labels.push(t);
+            summary.stepsChart.datasets[0].data.push(o._value);
+            summary.steps = o._value; // override with most recent
+            break;
+          case 'resting_hr':
+            summary.resting_hr = o._value;
+            break;
+          case 'vo2max':
+            summary.vo2max = o._value;
+            break;
+          case 'sleep_hours':
+            summary.sleep_hours = o._value;
+            break;
+        }
+      },
+      error(error) {
+        reject(error);
+      },
+      complete() {
+        resolve(summary);
+      }
+    });
+  });
 }
 
-const rawData = fs.readFileSync(filePath)
-const data = JSON.parse(rawData)
-
-writeGarminSummary({
-  steps: data.steps,
-  vo2max: data.vo2max,
-  resting_hr: data.resting_hr,
-  sleep_hours: data.sleep_hours
-}).then(() => {
-  console.log('Data written to InfluxDB.')
-})
+module.exports = { fetchGarminSummary };

--- a/api/index.js
+++ b/api/index.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
-const { fetchGarminSummary } = require('./influx');
+const { fetchGarminSummary } = require('./importGarmin'); // assumes this function is exported
 
 dotenv.config();
 
@@ -12,14 +12,14 @@ app.use(cors());
 
 app.get('/api/summary', async (req, res) => {
   try {
-    const data = await fetchGarminSummary();
-    res.json(data);
+    const summary = await fetchGarminSummary(); // assumes this returns { steps, resting_hr, vo2max, sleep_hours, stepsChart }
+    res.json(summary);
   } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Failed to fetch data from InfluxDB' });
+    console.error('API error:', err.message);
+    res.status(500).json({ error: 'Failed to fetch Garmin summary' });
   }
 });
 
 app.listen(PORT, () => {
-  console.log(`API running on http://localhost:${PORT}`);
+  console.log(`✅ API running on http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- fetch daily summary from InfluxDB
- update API route to use `fetchGarminSummary`

## Testing
- `npm test` *(fails: no test script)*
- `npm test` in `api` *(fails: no test specified)*
- `npm test` in `frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687ee6653ee483248b724b3f0098e229