### PR TITLE
Add start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a custom dashboard hosted at `/ajo/` for visualizing Andy's Garmin data.
 1. Start the backend API:
 ```bash
 cd api
-node index.js
+npm start
 ```
 
 2. Start the frontend (via Vite or Next.js):

--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add npm start command for API
- document npm start usage in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ee8b4c6bc83249bfe61fa40ec549e