### PR TITLE
Add env example and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ This is a custom dashboard hosted at `/ajo/` for visualizing Andy's Garmin data.
 
 ## Setup
 
-1. Start the backend API:
+1. Copy `api/.env.example` to `api/.env` and fill in your InfluxDB details.
+
+2. Start the backend API:
 ```bash
 cd api
 node index.js
 ```
 
-2. Start the frontend (via Vite or Next.js):
+3. Start the frontend (via Vite or Next.js):
 ```bash
 cd frontend
 npm install

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,8 @@
+# Example environment variables for the API
+# Copy this file to .env and fill in your real values
+
+INFLUX_URL=http://localhost:8086
+INFLUX_TOKEN=your-token
+INFLUX_ORG=your-org
+INFLUX_BUCKET=your-bucket
+#PORT=3001


### PR DESCRIPTION
## Summary
- add `.env.example` to document required API variables
- instruct how to create `.env` in the project README

## Testing
- `npm test` in `api`
- `npm run lint` in `frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687ee8af749083248ce7aaa9f6b5c693