### PR TITLE
Improve InfluxDB setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,25 @@
 # Andy's Garmin Dashboard
 
-This is a custom dashboard hosted at `/ajo/` for visualizing Andy's Garmin data.
+This is a custom dashboard hosted at `/ajo/` for visualizing Andy's Garmin data. The API queries an InfluxDB instance that stores the metrics.
 
 ## Project Structure
 
 - `frontend/`: React + Tailwind dashboard UI
-- `api/`: Node.js Express API returning mock Garmin data
+- `api/`: Node.js Express API that queries InfluxDB
+
+## Configuration
+
+Create an `.env` file inside the `api/` folder with the following variables:
+
+```dotenv
+INFLUX_URL=<your InfluxDB URL>
+INFLUX_ORG=<your organization>
+INFLUX_BUCKET=<your bucket>
+INFLUX_TOKEN=<your access token>
+PORT=3001
+```
+
+These values are required for the API to connect to InfluxDB and define the port the server listens on.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- mention that the API reads from InfluxDB
- document required environment variables and how to create a `.env`

## Testing
- `npm test` in `api` (fails: no test specified)
- `npm test` in `frontend` (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_687ee8ae24ec8324b4e786bd2dcc333b