### PR TITLE
Fix dotenv initialization order

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,9 +1,10 @@
 const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
-const { fetchGarminSummary } = require('./importGarmin'); // assumes this function is exported
 
 dotenv.config();
+
+const { fetchGarminSummary } = require('./importGarmin'); // assumes this function is exported
 
 const app = express();
 const PORT = process.env.PORT || 3001;


### PR DESCRIPTION
## Summary
- load environment variables before importing Garmin code

## Testing
- `npm test --silent` in `api`
- `node index.js` (server starts)


------
https://chatgpt.com/codex/tasks/task_e_687ee8a8b7548324a46b40c462ad9b44