### PR TITLE
Add example env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-hi
+# Garmin Dashboard
+
+This repository contains a small demo API and frontend for Garmin data.
+
+## Configuration
+
+An example environment file is provided at `api/.env.example`.
+Copy it to `.env` inside the `api` folder and fill in your real credentials:
+
+```bash
+cp api/.env.example api/.env
+```
+
+Edit `api/.env` and replace the placeholder values for `GARMIN_EMAIL` and `GARMIN_PASSWORD`. You can adjust `PORT` if needed.
+
+## Running the API
+
+Install dependencies and start the server:
+
+```bash
+cd api
+npm install
+node index.js
+```

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,3 @@
+PORT=3002
+GARMIN_EMAIL=your_email
+GARMIN_PASSWORD=your_password


### PR DESCRIPTION
## Summary
- document environment setup in the README
- add `api/.env.example` for configuration

## Testing
- `npm test` (fails: "Error: no test specified")

------
https://chatgpt.com/codex/tasks/task_e_688018337f4883249f548999e1f32693