### PR TITLE
Add development proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Write commit messages in the present-tense imperative, describing what the commi
 2. Run `npm install` in the `api` folder.
 3. Start the API with `node api/index.js`.
 4. From `frontend/react-app`, run `npm install` then `npm run dev` to start the React app.
+5. Requests to `/api` from the React dev server are proxied to `http://localhost:3002`.

--- a/frontend/react-app/vite.config.js
+++ b/frontend/react-app/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3002',
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- proxy `/api` requests to the backend during development
- note proxy behavior in setup docs

## Testing
- `npm test` in `api` (fails: no test specified)
- `npm test` in `frontend/react-app` (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_688024373b1c8324b177926edface636