### PR TITLE
Add start script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ Write commit messages in the present-tense imperative, describing what the commi
 
 1. Copy `.env.example` to `.env` and fill in your Garmin credentials and InfluxDB connection details.
 2. Run `npm install` in the `api` folder.
-3. Start the API with `node api/index.js`.
+3. Start the API with `npm start` in the `api` folder.
 4. From `frontend/react-app`, run `npm install` then `npm run dev` to start the React app.

--- a/api/package.json
+++ b/api/package.json
@@ -11,7 +11,8 @@
   "main": "index.js",
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add a start script to `api/package.json`
- update README instructions to use `npm start`

## Testing
- `npm test` *(fails: no test specified)*
- `npm start` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6880243216e88324b63cf28733c3655b