### PR TITLE
Add PORT environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ INFLUX_URL=http://localhost:8086
 INFLUX_TOKEN=your-token
 INFLUX_ORG=your-org
 INFLUX_BUCKET=garmin
+PORT=3002

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Write commit messages in the present-tense imperative, describing what the commi
 
 ## Setup
 
-1. Copy `.env.example` to `.env` and fill in your Garmin credentials and InfluxDB connection details.
+1. Copy `.env.example` to `.env` and fill in your Garmin credentials, InfluxDB connection details, and optional `PORT` for the API (defaults to 3002).
 2. Run `npm install` in the `api` folder.
 3. Start the API with `node api/index.js`.
 4. From `frontend/react-app`, run `npm install` then `npm run dev` to start the React app.

--- a/api/index.js
+++ b/api/index.js
@@ -4,7 +4,7 @@ const { fetchGarminSummary } = require('./scraper');
 require('dotenv').config();
 
 const app = express();
-const port = 3002;
+const port = process.env.PORT || 3002;
 
 app.get('/api/summary', async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- allow overriding port in `api/index.js`
- add `PORT` value to `.env.example`
- mention `PORT` in README setup instructions

## Testing
- `npm test --silent` (root)
- `npm test --silent` in `api`
- `npm test --silent` in `frontend/react-app`

------
https://chatgpt.com/codex/tasks/task_e_6880242dd33c8324ae26a246f0521aeb