### PR TITLE
Add credential checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Write commit messages in the present-tense imperative, describing what the commi
 
 ## Setup
 
-1. Copy `.env.example` to `.env` and fill in your Garmin credentials, InfluxDB connection details, and optional `PORT` for the API (defaults to 3002).
+1. Copy `.env.example` to `.env` and fill in `GARMIN_EMAIL` and `GARMIN_PASSWORD` with your Garmin credentials. Add your InfluxDB connection details and optional `PORT` for the API (defaults to 3002).
 2. Run `npm install` in the `api` folder.
 3. Start the API with `npm start` in the `api` folder.
 4. From `frontend/react-app`, run `npm install` then `npm run dev` to start the React app.

--- a/api/scraper.js
+++ b/api/scraper.js
@@ -18,7 +18,14 @@ async function getStepsData(date) {
 }
 
 async function login() {
-  await gcClient.login(process.env.GARMIN_EMAIL, process.env.GARMIN_PASSWORD);
+  const { GARMIN_EMAIL, GARMIN_PASSWORD } = process.env;
+  if (!GARMIN_EMAIL) {
+    throw new Error('Missing GARMIN_EMAIL environment variable.');
+  }
+  if (!GARMIN_PASSWORD) {
+    throw new Error('Missing GARMIN_PASSWORD environment variable.');
+  }
+  await gcClient.login(GARMIN_EMAIL, GARMIN_PASSWORD);
 }
 
 async function writeToInflux(summary) {


### PR DESCRIPTION
## Summary
- throw an error if `GARMIN_EMAIL` or `GARMIN_PASSWORD` are missing
- clarify the environment variables in the setup docs

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688027a052cc83248b677b2ebc0fe74d