### PR TITLE
Check Garmin credentials before login

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ Husky is used to enforce this guideline. After installing dependencies, run
 3. Start the API with `npm start` in the `api` folder.
 4. From `frontend/react-app`, run `npm install` then `npm run dev` to start the React app.
 5. Requests to `/api` from the React dev server are proxied to `http://localhost:3002`.
+
+### Required Environment Variables
+
+Set the following variables with your Garmin credentials before starting the API:
+
+- `GARMIN_EMAIL`
+- `GARMIN_PASSWORD`

--- a/api/scraper.js
+++ b/api/scraper.js
@@ -4,6 +4,15 @@ const { InfluxDB, Point } = require('@influxdata/influxdb-client');
 
 const gcClient = new GarminConnect();
 
+function ensureGarminCredentials() {
+  if (!process.env.GARMIN_EMAIL) {
+    throw new Error('Missing GARMIN_EMAIL environment variable.');
+  }
+  if (!process.env.GARMIN_PASSWORD) {
+    throw new Error('Missing GARMIN_PASSWORD environment variable.');
+  }
+}
+
 function toDateString(date) {
   const offset = date.getTimezoneOffset();
   const offsetDate = new Date(date.getTime() - offset * 60 * 1000);
@@ -18,14 +27,8 @@ async function getStepsData(date) {
 }
 
 async function login() {
-  const { GARMIN_EMAIL, GARMIN_PASSWORD } = process.env;
-  if (!GARMIN_EMAIL) {
-    throw new Error('Missing GARMIN_EMAIL environment variable.');
-  }
-  if (!GARMIN_PASSWORD) {
-    throw new Error('Missing GARMIN_PASSWORD environment variable.');
-  }
-  await gcClient.login(GARMIN_EMAIL, GARMIN_PASSWORD);
+  ensureGarminCredentials();
+  await gcClient.login(process.env.GARMIN_EMAIL, process.env.GARMIN_PASSWORD);
 }
 
 async function writeToInflux(summary) {


### PR DESCRIPTION
## Summary
- check for Garmin credentials before calling `gcClient.login`
- document required environment variables

## Testing
- `npm test` (fails: Error: no test specified)
- `(cd api && npm test)` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68802c18dc9883248898acb504ce2400