### PR TITLE
Add scheduled sync and weekly endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Garmin Dashboard Ajo
 
-This project contains a simple Express API for fetching Garmin data and a frontend built with React and Vite.
+This project contains a simple Express API for fetching Garmin data and a frontend built with React and Vite. The API stores daily metrics in InfluxDB, exposes a weekly history endpoint and runs a scheduled fetch each night.
 
 ## Commit Message Guidelines
 
@@ -22,6 +22,7 @@ Husky is used to enforce this guideline. After installing dependencies, run
 3. Start the API with `npm start` in the `api` folder.
 4. From `frontend/react-app`, run `npm install` then `npm run dev` to start the React app.
 5. Requests to `/api` from the React dev server are proxied to `http://localhost:3002`.
+6. The server schedules a daily Garmin sync at midnight and exposes `/api/weekly` for historical data.
 
 ## Running Tests
 

--- a/api/__tests__/index.test.js
+++ b/api/__tests__/index.test.js
@@ -1,11 +1,12 @@
 const request = require('supertest');
 
 jest.mock('../scraper', () => ({
-  fetchGarminSummary: jest.fn().mockResolvedValue({ steps: 1 })
+  fetchGarminSummary: jest.fn().mockResolvedValue({ steps: 1 }),
+  fetchWeeklySummary: jest.fn().mockResolvedValue([{ time: '2024-01-01', steps: 1 }])
 }));
 
 const app = require('../index');
-const { fetchGarminSummary } = require('../scraper');
+const { fetchGarminSummary, fetchWeeklySummary } = require('../scraper');
 
 describe('GET /api/summary', () => {
   it('responds with summary json', async () => {
@@ -13,5 +14,14 @@ describe('GET /api/summary', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ steps: 1 });
     expect(fetchGarminSummary).toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/weekly', () => {
+  it('responds with weekly data', async () => {
+    const res = await request(app).get('/api/weekly');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ time: '2024-01-01', steps: 1 }]);
+    expect(fetchWeeklySummary).toHaveBeenCalled();
   });
 });

--- a/api/__tests__/scraper.test.js
+++ b/api/__tests__/scraper.test.js
@@ -4,6 +4,9 @@ const mockSleep = { dailySleepDTO: { sleepTimeSeconds: 28800 } };
 const mockStepsData = [
   { startGMT: new Date('2024-01-01T00:00:00Z').toISOString(), steps: 100 },
 ];
+const mockIntensity = 30;
+const mockTraining = 500;
+const mockBattery = 75;
 
 jest.mock('garmin-connect', () => {
   const gcClient = {
@@ -11,8 +14,18 @@ jest.mock('garmin-connect', () => {
     getSteps: jest.fn().mockResolvedValue(mockSteps),
     getHeartRate: jest.fn().mockResolvedValue(mockHr),
     getSleepData: jest.fn().mockResolvedValue(mockSleep),
+    getIntensityMinutes: jest.fn().mockResolvedValue(mockIntensity),
+    getTrainingLoad: jest.fn().mockResolvedValue(mockTraining),
+    getBodyBattery: jest.fn().mockResolvedValue(mockBattery),
     getUserProfile: jest.fn().mockResolvedValue({ displayName: 'user' }),
-    client: { get: jest.fn().mockResolvedValue(mockStepsData) },
+    client: {
+      get: jest
+        .fn()
+        .mockResolvedValueOnce(mockStepsData)
+        .mockResolvedValueOnce({ intensityMinutes: mockIntensity })
+        .mockResolvedValueOnce({ trainingLoad: mockTraining })
+        .mockResolvedValueOnce({ bodyBattery: mockBattery })
+    },
     url: { GC_API: 'http://mock' },
   };
   return { GarminConnect: jest.fn(() => gcClient) };
@@ -34,6 +47,9 @@ describe('fetchGarminSummary', () => {
     expect(summary).toHaveProperty('resting_hr', mockHr.restingHeartRate);
     expect(summary).toHaveProperty('vo2max', mockHr.vo2max);
     expect(summary).toHaveProperty('sleep_hours', 8);
+    expect(summary).toHaveProperty('intensity_minutes', mockIntensity);
+    expect(summary).toHaveProperty('training_load', mockTraining);
+    expect(summary).toHaveProperty('body_battery', mockBattery);
     expect(summary.stepsChart.datasets[0].data[0]).toBe(100);
   });
 });

--- a/api/index.js
+++ b/api/index.js
@@ -1,6 +1,7 @@
 
 const express = require('express');
-const { fetchGarminSummary } = require('./scraper');
+const { fetchGarminSummary, fetchWeeklySummary } = require('./scraper');
+const cron = require('node-cron');
 require('dotenv').config();
 
 const app = express();
@@ -16,9 +17,22 @@ app.get('/api/summary', async (req, res) => {
   }
 });
 
+app.get('/api/weekly', async (req, res) => {
+  try {
+    const data = await fetchWeeklySummary();
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to query InfluxDB' });
+  }
+});
+
 if (require.main === module) {
   app.listen(port, () => {
     console.log(`API running at http://localhost:${port}`);
+  });
+  cron.schedule('0 0 * * *', () => {
+    fetchGarminSummary().catch(err => console.error(err));
   });
 }
 

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -7,12 +7,13 @@
     "": {
       "name": "api",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@influxdata/influxdb-client": "^1.35.0",
         "dotenv": "^17.2.0",
         "express": "^5.1.0",
-        "garmin-connect": "^1.6.2"
+        "garmin-connect": "^1.6.2",
+        "node-cron": "^3.0.2"
       },
       "devDependencies": {
         "jest": "^29.7.0",
@@ -3597,6 +3598,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4575,6 +4588,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/api/package.json
+++ b/api/package.json
@@ -3,7 +3,8 @@
     "@influxdata/influxdb-client": "^1.35.0",
     "dotenv": "^17.2.0",
     "express": "^5.1.0",
-    "garmin-connect": "^1.6.2"
+    "garmin-connect": "^1.6.2",
+    "node-cron": "^3.0.2"
   },
   "name": "api",
   "version": "1.0.0",

--- a/api/scraper.js
+++ b/api/scraper.js
@@ -26,6 +26,29 @@ async function getStepsData(date) {
   return gcClient.client.get(url, { params: { date: dateString } });
 }
 
+async function getIntensityMinutes(date) {
+  const profile = await gcClient.getUserProfile();
+  const dateString = toDateString(date);
+  const url = `${gcClient.url.GC_API}/wellness-service/wellness/dailyIntensityMinutes/${profile.displayName}`;
+  const data = await gcClient.client.get(url, { params: { date: dateString } });
+  return data.intensityMinutes || 0;
+}
+
+async function getTrainingLoad(date) {
+  const dateString = toDateString(date);
+  const url = `${gcClient.url.GC_API}/training-service/v2/athlete/trainingload/${dateString}`;
+  const data = await gcClient.client.get(url);
+  return data.trainingLoad || 0;
+}
+
+async function getBodyBattery(date) {
+  const profile = await gcClient.getUserProfile();
+  const dateString = toDateString(date);
+  const url = `${gcClient.url.GC_API}/wellness-service/wellness/bodyBattery/${profile.displayName}`;
+  const data = await gcClient.client.get(url, { params: { date: dateString } });
+  return data.bodyBattery || 0;
+}
+
 async function login() {
   ensureGarminCredentials();
   await gcClient.login(process.env.GARMIN_EMAIL, process.env.GARMIN_PASSWORD);
@@ -40,7 +63,10 @@ async function writeToInflux(summary) {
     .floatField('steps', summary.steps)
     .floatField('resting_hr', summary.resting_hr)
     .floatField('vo2max', summary.vo2max || 0)
-    .floatField('sleep_hours', summary.sleep_hours);
+    .floatField('sleep_hours', summary.sleep_hours)
+    .floatField('intensity_minutes', summary.intensity_minutes)
+    .floatField('training_load', summary.training_load)
+    .floatField('body_battery', summary.body_battery);
   writeApi.writePoint(point);
   await writeApi.close();
 }
@@ -53,12 +79,18 @@ async function fetchGarminSummary() {
   const hr = await gcClient.getHeartRate(today);
   const sleep = await gcClient.getSleepData(today);
   const stepsData = await getStepsData(today);
+  const intensity = await getIntensityMinutes(today);
+  const training = await getTrainingLoad(today);
+  const battery = await getBodyBattery(today);
 
   const summary = {
     steps,
     resting_hr: hr.restingHeartRate,
     vo2max: hr.vo2max || 0,
     sleep_hours: (sleep.dailySleepDTO.sleepTimeSeconds || 0) / 3600,
+    intensity_minutes: intensity,
+    training_load: training,
+    body_battery: battery,
     stepsChart: {
       labels: stepsData.map(d => new Date(d.startGMT).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })),
       datasets: [{
@@ -76,4 +108,31 @@ async function fetchGarminSummary() {
   return summary;
 }
 
-module.exports = { fetchGarminSummary };
+async function fetchWeeklySummary() {
+  if (!process.env.INFLUX_URL || !process.env.INFLUX_TOKEN || !process.env.INFLUX_ORG || !process.env.INFLUX_BUCKET) {
+    return [];
+  }
+  const influx = new InfluxDB({ url: process.env.INFLUX_URL, token: process.env.INFLUX_TOKEN });
+  const queryApi = influx.getQueryApi(process.env.INFLUX_ORG);
+  const query = `from(bucket: "${process.env.INFLUX_BUCKET}")
+    |> range(start: -7d)
+    |> filter(fn: (r) => r._measurement == "garmin_summary")
+    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")`;
+  const results = [];
+  await queryApi.collectRows(query, (row, tableMeta) => {
+    const o = tableMeta.toObject(row);
+    results.push({
+      time: o._time,
+      steps: o.steps,
+      resting_hr: o.resting_hr,
+      vo2max: o.vo2max,
+      sleep_hours: o.sleep_hours,
+      intensity_minutes: o.intensity_minutes,
+      training_load: o.training_load,
+      body_battery: o.body_battery,
+    });
+  });
+  return results;
+}
+
+module.exports = { fetchGarminSummary, fetchWeeklySummary };

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,27 +13,45 @@
 <body>
   <h1>Garmin Dashboard</h1>
   <div id="summary"></div>
+  <canvas id="weeklyChart" class="chart-container"></canvas>
   <canvas id="stepsChart" class="chart-container"></canvas>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
-    fetch('/api/summary')
-      .then(res => res.json())
-      .then(data => {
-        document.getElementById('summary').innerHTML = `
-          <p><strong>Steps:</strong> ${data.steps}</p>
-          <p><strong>Resting HR:</strong> ${data.resting_hr}</p>
-          <p><strong>VO2 Max:</strong> ${data.vo2max}</p>
-          <p><strong>Sleep:</strong> ${data.sleep_hours} hrs</p>
-        `;
-        new Chart(document.getElementById('stepsChart'), {
-          type: 'line',
-          data: data.stepsChart,
-          options: {
-            responsive: true,
-            scales: { y: { beginAtZero: true } },
-          }
-        });
+    Promise.all([
+      fetch('/api/summary').then(r => r.json()),
+      fetch('/api/weekly').then(r => r.json())
+    ]).then(([data, weekly]) => {
+      document.getElementById('summary').innerHTML = `
+        <p><strong>Steps:</strong> ${data.steps}</p>
+        <p><strong>Resting HR:</strong> ${data.resting_hr}</p>
+        <p><strong>VO2 Max:</strong> ${data.vo2max}</p>
+        <p><strong>Sleep:</strong> ${data.sleep_hours} hrs</p>
+        <p><strong>Intensity Minutes:</strong> ${data.intensity_minutes}</p>
+        <p><strong>Training Load:</strong> ${data.training_load}</p>
+        <p><strong>Body Battery:</strong> ${data.body_battery}</p>
+      `;
+      new Chart(document.getElementById('stepsChart'), {
+        type: 'line',
+        data: data.stepsChart,
+        options: { responsive: true, scales: { y: { beginAtZero: true } } }
       });
+      const weeklyData = {
+        labels: weekly.map(d => new Date(d.time).toLocaleDateString()),
+        datasets: [{
+          label: 'Steps',
+          data: weekly.map(d => d.steps),
+          fill: true,
+          backgroundColor: 'rgba(40,167,69,0.1)',
+          borderColor: 'rgba(40,167,69,1)',
+          tension: 0.3
+        }]
+      };
+      new Chart(document.getElementById('weeklyChart'), {
+        type: 'line',
+        data: weeklyData,
+        options: { responsive: true, scales: { y: { beginAtZero: true } } }
+      });
+    });
   </script>
 </body>
 </html>

--- a/frontend/react-app/src/App.jsx
+++ b/frontend/react-app/src/App.jsx
@@ -7,15 +7,20 @@ Chart.register(LineElement, PointElement, LinearScale, CategoryScale, Filler)
 
 function App() {
   const [summary, setSummary] = useState(null)
+  const [weekly, setWeekly] = useState(null)
 
   useEffect(() => {
     fetch('/api/summary')
       .then(res => res.json())
       .then(setSummary)
       .catch(err => console.error(err))
+    fetch('/api/weekly')
+      .then(res => res.json())
+      .then(setWeekly)
+      .catch(err => console.error(err))
   }, [])
 
-  if (!summary) return <p>Loading...</p>
+  if (!summary || !weekly) return <p>Loading...</p>
 
   return (
     <div className="dashboard">
@@ -25,10 +30,29 @@ function App() {
         <li><strong>Resting HR:</strong> {summary.resting_hr}</li>
         <li><strong>VO2 Max:</strong> {summary.vo2max}</li>
         <li><strong>Sleep:</strong> {summary.sleep_hours} hrs</li>
+        <li><strong>Intensity Minutes:</strong> {summary.intensity_minutes}</li>
+        <li><strong>Training Load:</strong> {summary.training_load}</li>
+        <li><strong>Body Battery:</strong> {summary.body_battery}</li>
       </ul>
       <div className="chart-container">
         <Line
           data={summary.stepsChart}
+          options={{ responsive: true, scales: { y: { beginAtZero: true } } }}
+        />
+      </div>
+      <div className="chart-container">
+        <Line
+          data={{
+            labels: weekly.map(d => new Date(d.time).toLocaleDateString()),
+            datasets: [{
+              label: 'Steps',
+              data: weekly.map(d => d.steps),
+              fill: true,
+              backgroundColor: 'rgba(40,167,69,0.1)',
+              borderColor: 'rgba(40,167,69,1)',
+              tension: 0.3,
+            }],
+          }}
           options={{ responsive: true, scales: { y: { beginAtZero: true } } }}
         />
       </div>

--- a/frontend/react-app/src/App.test.jsx
+++ b/frontend/react-app/src/App.test.jsx
@@ -11,12 +11,16 @@ describe('App', () => {
       resting_hr: 60,
       vo2max: 50,
       sleep_hours: 8,
+      intensity_minutes: 30,
+      training_load: 500,
+      body_battery: 80,
       stepsChart: { labels: ['00:00'], datasets: [{ data: [100] }] },
     };
-    global.fetch = vi.fn(() =>
-      Promise.resolve({ json: () => Promise.resolve(summary) })
-    );
+    const weekly = [{ time: '2024-01-01', steps: 100 }];
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ json: () => Promise.resolve(summary) })
+      .mockResolvedValueOnce({ json: () => Promise.resolve(weekly) });
     render(<App />);
-    await screen.findByText('100');
+    await screen.findByText('500');
   });
 });


### PR DESCRIPTION
## Summary
- extend Garmin metrics saved to InfluxDB
- add weekly history query and cron job
- show new metrics in static page and React app
- update tests for the new API behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68802e1c66a083248175dd969149c202