### PR TITLE
Fix Garmin env loading

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,8 +1,8 @@
 
+require('dotenv').config();
 const express = require('express');
 const { fetchGarminSummary, fetchWeeklySummary } = require('./scraper');
 const cron = require('node-cron');
-require('dotenv').config();
 
 const app = express();
 const port = process.env.PORT || 3002;

--- a/api/scraper.js
+++ b/api/scraper.js
@@ -2,7 +2,10 @@
 const { GarminConnect } = require('garmin-connect');
 const { InfluxDB, Point } = require('@influxdata/influxdb-client');
 
-const gcClient = new GarminConnect();
+const gcClient = new GarminConnect({
+  username: process.env.GARMIN_EMAIL,
+  password: process.env.GARMIN_PASSWORD,
+});
 
 function ensureGarminCredentials() {
   if (!process.env.GARMIN_EMAIL) {


### PR DESCRIPTION
## Summary
- load dotenv before importing the scraper
- initialize GarminConnect with credentials

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880343ea2288324a75ee002446a3e49