### PR TITLE
Use async login file access

### DIFF
--- a/api/__tests__/scraper.test.js
+++ b/api/__tests__/scraper.test.js
@@ -37,7 +37,7 @@ jest.mock('garmin-connect', () => {
 
 
 describe('fetchGarminSummary', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     delete process.env.INFLUX_URL;
     delete process.env.GARMIN_COOKIE_PATH;
     jest.resetModules();
@@ -46,15 +46,20 @@ describe('fetchGarminSummary', () => {
     const fs = require('fs');
     const path = require('path');
     const cookiePath = path.join(__dirname, 'session.json');
-    fs.writeFileSync(cookiePath, JSON.stringify({ oauth1: 'a', oauth2: 'b' }));
+    await fs.promises.writeFile(
+      cookiePath,
+      JSON.stringify({ oauth1: 'a', oauth2: 'b' })
+    );
     process.env.GARMIN_COOKIE_PATH = cookiePath;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     const fs = require('fs');
-    if (process.env.GARMIN_COOKIE_PATH && fs.existsSync(process.env.GARMIN_COOKIE_PATH)) {
-      fs.unlinkSync(process.env.GARMIN_COOKIE_PATH);
-    }
+    const path = require('path');
+    const cookiePath = path.join(__dirname, 'session.json');
+    try {
+      await fs.promises.unlink(cookiePath);
+    } catch {}
   });
 
   it('returns formatted summary', async () => {

--- a/api/scraper.js
+++ b/api/scraper.js
@@ -45,14 +45,18 @@ async function login() {
   if (!process.env.GARMIN_COOKIE_PATH) {
     throw new Error('GARMIN_COOKIE_PATH is required');
   }
-  if (!fs.existsSync(process.env.GARMIN_COOKIE_PATH)) {
+  try {
+    await fs.promises.access(process.env.GARMIN_COOKIE_PATH);
+  } catch {
     throw new Error(
       `Cookie file not found: ${process.env.GARMIN_COOKIE_PATH}`
     );
   }
-  const data = JSON.parse(
-    fs.readFileSync(process.env.GARMIN_COOKIE_PATH, 'utf8')
+  const file = await fs.promises.readFile(
+    process.env.GARMIN_COOKIE_PATH,
+    'utf8'
   );
+  const data = JSON.parse(file);
   if (typeof gcClient.setSession === 'function') {
     gcClient.setSession(data);
   } else if (typeof gcClient.loadToken === 'function') {


### PR DESCRIPTION
## Summary
- refactor login to use `fs.promises`
- update scraper tests for async file handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880c4ee2290832484e440e58f7ced30