### PR TITLE
Add 404 middleware

### DIFF
--- a/api/__tests__/index.test.js
+++ b/api/__tests__/index.test.js
@@ -25,3 +25,11 @@ describe('GET /api/weekly', () => {
     expect(fetchWeeklySummary).toHaveBeenCalled();
   });
 });
+
+describe('Unknown routes', () => {
+  it('responds with 404', async () => {
+    const res = await request(app).get('/does/not/exist');
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not found' });
+  });
+});

--- a/api/index.js
+++ b/api/index.js
@@ -27,6 +27,9 @@ app.get('/api/weekly', async (req, res) => {
   }
 });
 
+// Catch-all handler for unknown routes
+app.use((req, res) => res.status(404).json({ error: 'Not found' }));
+
 if (require.main === module) {
   app.listen(port, () => {
     console.log(`API running at http://localhost:${port}`);


### PR DESCRIPTION
## Summary
- add catch-all 404 handler to API
- test 404 response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880c4e83ee88324a716517005e4a2d9