### PR TITLE
Handle failed fetch

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,8 +18,18 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
     Promise.all([
-      fetch('/api/summary').then(r => r.json()),
-      fetch('/api/weekly').then(r => r.json())
+      fetch('/api/summary').then(async r => {
+        if (!r.ok) {
+          throw new Error(await r.text())
+        }
+        return r.json()
+      }),
+      fetch('/api/weekly').then(async r => {
+        if (!r.ok) {
+          throw new Error(await r.text())
+        }
+        return r.json()
+      })
     ]).then(([data, weekly]) => {
       document.getElementById('summary').innerHTML = `
         <p><strong>Steps:</strong> ${data.steps}</p>

--- a/frontend/react-app/src/App.jsx
+++ b/frontend/react-app/src/App.jsx
@@ -11,11 +11,21 @@ function App() {
 
   useEffect(() => {
     fetch('/api/summary')
-      .then(res => res.json())
+      .then(async res => {
+        if (!res.ok) {
+          throw new Error(await res.text())
+        }
+        return res.json()
+      })
       .then(setSummary)
       .catch(err => console.error(err))
     fetch('/api/weekly')
-      .then(res => res.json())
+      .then(async res => {
+        if (!res.ok) {
+          throw new Error(await res.text())
+        }
+        return res.json()
+      })
       .then(setWeekly)
       .catch(err => console.error(err))
   }, [])

--- a/frontend/react-app/src/App.test.jsx
+++ b/frontend/react-app/src/App.test.jsx
@@ -18,8 +18,16 @@ describe('App', () => {
     };
     const weekly = [{ time: '2024-01-01', steps: 100 }];
     global.fetch = vi.fn()
-      .mockResolvedValueOnce({ json: () => Promise.resolve(summary) })
-      .mockResolvedValueOnce({ json: () => Promise.resolve(weekly) });
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(summary),
+        text: () => Promise.resolve('')
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(weekly),
+        text: () => Promise.resolve('')
+      });
     render(<App />);
     await screen.findByText('500');
   });


### PR DESCRIPTION
## Summary
- add HTTP error handling in React and vanilla JS
- update tests for new fetch response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68811d3746d48324a38bdbef22b7d304