### PR TITLE
Update husky hook script

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,9 +1,20 @@
-echo "husky - DEPRECATED
-
-Please remove the following two lines from $0:
-
 #!/usr/bin/env sh
-. \"\$(dirname -- \"\$0\")/_/husky.sh\"
+[ "$HUSKY" = "2" ] && set -x
+h="${0##*/}"
+s="${0%/*/*}/$h"
 
-They WILL FAIL in v10.0.0
-"
+[ ! -f "$s" ] && exit 0
+
+for f in "${XDG_CONFIG_HOME:-$HOME/.config}/husky/init.sh" "$HOME/.huskyrc.sh"; do
+  # shellcheck disable=SC1090
+  [ -f "$f" ] && . "$f"
+done
+
+[ "$HUSKY" = "0" ] && exit 0
+
+sh -e "$s" "$@"
+c=$?
+
+[ $c != 0 ] && echo "husky - $h script failed (code $c)"
+[ $c = 127 ] && echo "husky - command not found in PATH=$PATH"
+exit $c

--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ Set the following variable before starting the API:
 This project is licensed under the [MIT License](LICENSE).
 
 
+\nTest change


### PR DESCRIPTION
## Summary
- replace deprecated `.husky/_/husky.sh` with the Husky v9 script
- add a small README change to verify hooks run

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68811d028438832482293105ab670dc0