### PR TITLE
Add error state to React app

### DIFF
--- a/frontend/react-app/src/App.jsx
+++ b/frontend/react-app/src/App.jsx
@@ -8,6 +8,7 @@ Chart.register(LineElement, PointElement, LinearScale, CategoryScale, Filler)
 function App() {
   const [summary, setSummary] = useState(null)
   const [weekly, setWeekly] = useState(null)
+  const [error, setError] = useState(null)
 
   useEffect(() => {
     fetch('/api/summary')
@@ -18,7 +19,10 @@ function App() {
         return res.json()
       })
       .then(setSummary)
-      .catch(err => console.error(err))
+      .catch(err => {
+        console.error(err)
+        setError(err.message)
+      })
     fetch('/api/weekly')
       .then(async res => {
         if (!res.ok) {
@@ -27,9 +31,13 @@ function App() {
         return res.json()
       })
       .then(setWeekly)
-      .catch(err => console.error(err))
+      .catch(err => {
+        console.error(err)
+        setError(err.message)
+      })
   }, [])
 
+  if (error) return <p role="alert">Error: {error}</p>
   if (!summary || !weekly) return <p>Loading...</p>
 
   return (

--- a/frontend/react-app/src/App.test.jsx
+++ b/frontend/react-app/src/App.test.jsx
@@ -31,4 +31,18 @@ describe('App', () => {
     render(<App />);
     await screen.findByText('500');
   });
+
+  it('shows error message if fetch fails', async () => {
+    global.fetch = vi.fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([]),
+        text: () => Promise.resolve('')
+      })
+
+    render(<App />)
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('fail')
+  })
 });


### PR DESCRIPTION
## Summary
- store fetch errors in state
- render an alert if summary or weekly fetch fails
- test error handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688120a11da883249628384852c96d89