### PR TITLE
Handle Garmin cookie error

### DIFF
--- a/api/__tests__/index.test.js
+++ b/api/__tests__/index.test.js
@@ -23,6 +23,13 @@ describe('GET /api/summary', () => {
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'Failed to fetch Garmin data' });
   });
+
+  it('returns cookie path error', async () => {
+    fetchGarminSummary.mockRejectedValue(new Error('Cookie file not found'));
+    const res = await request(app).get('/api/summary');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Cookie file not found' });
+  });
 });
 
 describe('GET /api/weekly', () => {

--- a/api/index.js
+++ b/api/index.js
@@ -13,7 +13,15 @@ app.get('/api/summary', async (req, res) => {
     res.json(summary);
   } catch (err) {
     console.error(err);
-    res.status(500).json({ error: 'Failed to fetch Garmin data' });
+    if (
+      err.message &&
+      (err.message.includes('GARMIN_COOKIE_PATH') ||
+        err.message.includes('Cookie file not found'))
+    ) {
+      res.status(500).json({ error: err.message });
+    } else {
+      res.status(500).json({ error: 'Failed to fetch Garmin data' });
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- return detailed cookie file errors in API
- test cookie file error handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688121ebe25883248e190a966e6d5351