### PR TITLE
Fix loading of root environment variables

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,5 +1,8 @@
 
-require('dotenv').config();
+const path = require('path');
+// Load environment variables from the repo root .env file so running the API
+// from the api/ directory works as documented.
+require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
 const express = require('express');
 const { fetchGarminSummary, fetchWeeklySummary } = require('./scraper');
 const cron = require('node-cron');


### PR DESCRIPTION
## Summary
- make API server load `.env` from the repository root

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688123d1ec0083248129926facba88e5