### PR TITLE
Use userId for Garmin API calls

### DIFF
--- a/api/__tests__/scraper.test.js
+++ b/api/__tests__/scraper.test.js
@@ -20,7 +20,7 @@ jest.mock('garmin-connect', () => {
     getIntensityMinutes: jest.fn().mockResolvedValue(mockIntensity),
     getTrainingLoad: jest.fn().mockResolvedValue(mockTraining),
     getBodyBattery: jest.fn().mockResolvedValue(mockBattery),
-    getUserProfile: jest.fn().mockResolvedValue({ displayName: 'user' }),
+    getUserProfile: jest.fn().mockResolvedValue({ userId: 'user' }),
     client: {
       get: jest
         .fn()

--- a/api/scraper.js
+++ b/api/scraper.js
@@ -14,14 +14,14 @@ function toDateString(date) {
 async function getStepsData(date) {
   const profile = await gcClient.getUserProfile();
   const dateString = toDateString(date);
-  const url = `${gcClient.url.GC_API}/wellness-service/wellness/dailySummaryChart/${profile.displayName}`;
+  const url = `${gcClient.url.GC_API}/wellness-service/wellness/dailySummaryChart/${profile.userId}`;
   return gcClient.client.get(url, { params: { date: dateString } });
 }
 
 async function getIntensityMinutes(date) {
   const profile = await gcClient.getUserProfile();
   const dateString = toDateString(date);
-  const url = `${gcClient.url.GC_API}/wellness-service/wellness/dailyIntensityMinutes/${profile.displayName}`;
+  const url = `${gcClient.url.GC_API}/wellness-service/wellness/dailyIntensityMinutes/${profile.userId}`;
   const data = await gcClient.client.get(url, { params: { date: dateString } });
   return data.intensityMinutes || 0;
 }
@@ -36,7 +36,7 @@ async function getTrainingLoad(date) {
 async function getBodyBattery(date) {
   const profile = await gcClient.getUserProfile();
   const dateString = toDateString(date);
-  const url = `${gcClient.url.GC_API}/wellness-service/wellness/bodyBattery/${profile.displayName}`;
+  const url = `${gcClient.url.GC_API}/wellness-service/wellness/bodyBattery/${profile.userId}`;
   const data = await gcClient.client.get(url, { params: { date: dateString } });
   return data.bodyBattery || 0;
 }


### PR DESCRIPTION
## Summary
- use `profile.userId` when calling Garmin wellness endpoints
- update scraper tests to mock `userId`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881389774e88324b672649357c9c031