### PR TITLE
Improve Garmin steps chart error handling

### DIFF
--- a/api/__tests__/scraper.test.js
+++ b/api/__tests__/scraper.test.js
@@ -83,4 +83,18 @@ describe('fetchGarminSummary', () => {
     process.env.GARMIN_COOKIE_PATH = '/no/such/file.json';
     await expect(fetchGarminSummary()).rejects.toThrow('Cookie file not found');
   });
+
+  it('sets stepsChart to null on error', async () => {
+    gcClient.client.get.mockReset();
+    gcClient.client.get
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce({ intensityMinutes: mockIntensity })
+      .mockResolvedValueOnce({ trainingLoad: mockTraining })
+      .mockResolvedValueOnce({ bodyBattery: mockBattery });
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const summary = await fetchGarminSummary();
+    expect(summary.stepsChart).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- handle errors when requesting Garmin step chart data
- log a warning and continue when steps chart fetch fails
- add test for steps chart error path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68813a020e388324a0b76036cc496531