### PR TITLE
Clarify env location and cookie path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,17 @@ A small dashboard that collects your Garmin activity data. The backend is an Exp
 
    This generates `~/garmin_session.json` containing your login cookies.
 
-2. **Create and edit `.env`**
+2. **Create and edit `.env`** (keep it in the repository root so the API can load `../.env`)
 
    ```bash
    cp .env.example .env
    ```
 
-   Set `GARMIN_COOKIE_PATH` to the session file and fill in the InfluxDB options. Change `PORT` if you need a different API port (defaults to `3002`).
+   Set `GARMIN_COOKIE_PATH` to the session file and fill in the InfluxDB
+   options. The path must be absolute (for example
+   `GARMIN_COOKIE_PATH=$HOME/garmin_session.json`) or it will be resolved
+   relative to `api/` when running `npm start`. Change `PORT` if you need a
+   different API port (defaults to `3002`).
 
 3. **Run the API**
 


### PR DESCRIPTION
## Summary
- update README quick-start instructions
  - keep `.env` in the repo root since `api/index.js` loads `../.env`
  - explain `GARMIN_COOKIE_PATH` must be absolute with example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68813c4a8b2c83248905c5f4dc65dbab