### PR TITLE
Refactor to use high level garmin‑connect API

### DIFF
--- a/api/scraper.js
+++ b/api/scraper.js
@@ -5,42 +5,6 @@ const fs = require('fs');
 
 const gcClient = new GarminConnect({ username: '', password: '' });
 
-function toDateString(date) {
-  const offset = date.getTimezoneOffset();
-  const offsetDate = new Date(date.getTime() - offset * 60 * 1000);
-  return offsetDate.toISOString().split('T')[0];
-}
-
-async function getStepsData(date) {
-  const profile = await gcClient.getUserProfile();
-  const dateString = toDateString(date);
-  const url = `${gcClient.url.GC_API}/wellness-service/wellness/dailySummaryChart/${profile.userId}`;
-  return gcClient.client.get(url, { params: { date: dateString } });
-}
-
-async function getIntensityMinutes(date) {
-  const profile = await gcClient.getUserProfile();
-  const dateString = toDateString(date);
-  const url = `${gcClient.url.GC_API}/wellness-service/wellness/dailyIntensityMinutes/${profile.userId}`;
-  const data = await gcClient.client.get(url, { params: { date: dateString } });
-  return data.intensityMinutes || 0;
-}
-
-async function getTrainingLoad(date) {
-  const dateString = toDateString(date);
-  const url = `${gcClient.url.GC_API}/training-service/v2/athlete/trainingload/${dateString}`;
-  const data = await gcClient.client.get(url);
-  return data.trainingLoad || 0;
-}
-
-async function getBodyBattery(date) {
-  const profile = await gcClient.getUserProfile();
-  const dateString = toDateString(date);
-  const url = `${gcClient.url.GC_API}/wellness-service/wellness/bodyBattery/${profile.userId}`;
-  const data = await gcClient.client.get(url, { params: { date: dateString } });
-  return data.bodyBattery || 0;
-}
-
 async function login() {
   if (!process.env.GARMIN_COOKIE_PATH) {
     throw new Error('GARMIN_COOKIE_PATH is required');
@@ -73,10 +37,7 @@ async function writeToInflux(summary) {
     .floatField('steps', summary.steps)
     .floatField('resting_hr', summary.resting_hr)
     .floatField('vo2max', summary.vo2max || 0)
-    .floatField('sleep_hours', summary.sleep_hours)
-    .floatField('intensity_minutes', summary.intensity_minutes)
-    .floatField('training_load', summary.training_load)
-    .floatField('body_battery', summary.body_battery);
+    .floatField('sleep_hours', summary.sleep_hours);
   writeApi.writePoint(point);
   await writeApi.close();
 }
@@ -88,45 +49,11 @@ async function fetchGarminSummary() {
   const steps = await gcClient.getSteps(today);
   const hr = await gcClient.getHeartRate(today);
   const sleep = await gcClient.getSleepData(today);
-  let stepsData;
-  try {
-    stepsData = await getStepsData(today);
-  } catch (err) {
-    console.warn('Failed to fetch steps data', err);
-    stepsData = null;
-  }
-  const intensity = await getIntensityMinutes(today);
-  const training = await getTrainingLoad(today);
-  const battery = await getBodyBattery(today);
-
   const summary = {
     steps,
     resting_hr: hr.restingHeartRate,
     vo2max: hr.vo2max || 0,
     sleep_hours: (sleep.dailySleepDTO.sleepTimeSeconds || 0) / 3600,
-    intensity_minutes: intensity,
-    training_load: training,
-    body_battery: battery,
-    stepsChart: stepsData
-      ? {
-          labels: stepsData.map(d =>
-            new Date(d.startGMT).toLocaleTimeString([], {
-              hour: '2-digit',
-              minute: '2-digit',
-            })
-          ),
-          datasets: [
-            {
-              label: 'Steps',
-              data: stepsData.map(d => d.steps),
-              fill: true,
-              backgroundColor: 'rgba(0, 123, 255, 0.1)',
-              borderColor: 'rgba(0, 123, 255, 1)',
-              tension: 0.3,
-            },
-          ],
-        }
-      : null,
   };
 
   await writeToInflux(summary);
@@ -152,9 +79,6 @@ async function fetchWeeklySummary() {
       resting_hr: o.resting_hr,
       vo2max: o.vo2max,
       sleep_hours: o.sleep_hours,
-      intensity_minutes: o.intensity_minutes,
-      training_load: o.training_load,
-      body_battery: o.body_battery,
     });
   });
   return results;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,7 +14,6 @@
   <h1>Garmin Dashboard</h1>
   <div id="summary"></div>
   <canvas id="weeklyChart" class="chart-container"></canvas>
-  <canvas id="stepsChart" class="chart-container"></canvas>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
     Promise.all([
@@ -36,15 +35,7 @@
         <p><strong>Resting HR:</strong> ${data.resting_hr}</p>
         <p><strong>VO2 Max:</strong> ${data.vo2max}</p>
         <p><strong>Sleep:</strong> ${data.sleep_hours} hrs</p>
-        <p><strong>Intensity Minutes:</strong> ${data.intensity_minutes}</p>
-        <p><strong>Training Load:</strong> ${data.training_load}</p>
-        <p><strong>Body Battery:</strong> ${data.body_battery}</p>
       `;
-      new Chart(document.getElementById('stepsChart'), {
-        type: 'line',
-        data: data.stepsChart,
-        options: { responsive: true, scales: { y: { beginAtZero: true } } }
-      });
       const weeklyData = {
         labels: weekly.map(d => new Date(d.time).toLocaleDateString()),
         datasets: [{

--- a/frontend/react-app/src/App.jsx
+++ b/frontend/react-app/src/App.jsx
@@ -48,16 +48,8 @@ function App() {
         <li><strong>Resting HR:</strong> {summary.resting_hr}</li>
         <li><strong>VO2 Max:</strong> {summary.vo2max}</li>
         <li><strong>Sleep:</strong> {summary.sleep_hours} hrs</li>
-        <li><strong>Intensity Minutes:</strong> {summary.intensity_minutes}</li>
-        <li><strong>Training Load:</strong> {summary.training_load}</li>
-        <li><strong>Body Battery:</strong> {summary.body_battery}</li>
       </ul>
-      <div className="chart-container">
-        <Line
-          data={summary.stepsChart}
-          options={{ responsive: true, scales: { y: { beginAtZero: true } } }}
-        />
-      </div>
+      
       <div className="chart-container">
         <Line
           data={{

--- a/frontend/react-app/src/App.test.jsx
+++ b/frontend/react-app/src/App.test.jsx
@@ -11,10 +11,6 @@ describe('App', () => {
       resting_hr: 60,
       vo2max: 50,
       sleep_hours: 8,
-      intensity_minutes: 30,
-      training_load: 500,
-      body_battery: 80,
-      stepsChart: { labels: ['00:00'], datasets: [{ data: [100] }] },
     };
     const weekly = [{ time: '2024-01-01', steps: 100 }];
     global.fetch = vi.fn()
@@ -29,7 +25,7 @@ describe('App', () => {
         text: () => Promise.resolve('')
       });
     render(<App />);
-    await screen.findByText('500');
+    await screen.findByText('100');
   });
 
   it('shows error message if fetch fails', async () => {


### PR DESCRIPTION
## Summary
- remove fragile custom API calls
- simplify scraper to only use official garmin-connect methods
- adjust frontend to display only supported data
- update tests accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688141656f6483249fb905746d1fa359