### PR TITLE
Add calendar history view

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 // from the api/ directory works as documented.
 require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
 const express = require('express');
-const { fetchGarminSummary, fetchWeeklySummary } = require('./scraper');
+const { fetchGarminSummary, fetchWeeklySummary, fetchHistory } = require('./scraper');
 const cron = require('node-cron');
 
 const app = express();
@@ -31,6 +31,17 @@ app.get('/api/summary', async (req, res) => {
 app.get('/api/weekly', async (req, res) => {
   try {
     const data = await fetchWeeklySummary();
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to query InfluxDB' });
+  }
+});
+
+app.get('/api/history', async (req, res) => {
+  const days = parseInt(req.query.days) || 7;
+  try {
+    const data = await fetchHistory(days);
     res.json(data);
   } catch (err) {
     console.error(err);

--- a/api/scraper.js
+++ b/api/scraper.js
@@ -60,14 +60,14 @@ async function fetchGarminSummary() {
   return summary;
 }
 
-async function fetchWeeklySummary() {
+async function fetchHistory(days = 7) {
   if (!process.env.INFLUX_URL || !process.env.INFLUX_TOKEN || !process.env.INFLUX_ORG || !process.env.INFLUX_BUCKET) {
     return [];
   }
   const influx = new InfluxDB({ url: process.env.INFLUX_URL, token: process.env.INFLUX_TOKEN });
   const queryApi = influx.getQueryApi(process.env.INFLUX_ORG);
   const query = `from(bucket: "${process.env.INFLUX_BUCKET}")
-    |> range(start: -7d)
+    |> range(start: -${days}d)
     |> filter(fn: (r) => r._measurement == "garmin_summary")
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")`;
   const results = [];
@@ -84,4 +84,8 @@ async function fetchWeeklySummary() {
   return results;
 }
 
-module.exports = { fetchGarminSummary, fetchWeeklySummary };
+async function fetchWeeklySummary() {
+  return fetchHistory(7);
+}
+
+module.exports = { fetchGarminSummary, fetchWeeklySummary, fetchHistory };

--- a/frontend/react-app/package-lock.json
+++ b/frontend/react-app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "chart.js": "^4.5.0",
         "react": "^19.1.0",
+        "react-calendar": "^4.8.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0"
       },
@@ -1651,7 +1652,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1801,6 +1802,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@wojtekmaj/date-utils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.5.1.tgz",
+      "integrity": "sha512-+i7+JmNiE/3c9FKxzWFi2IjRJ+KzZl1QPu6QNrsgaa2MuBgXvUy4gA1TVzf/JMdIIloB76xSKikTWuyYAIVLww==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
       }
     },
     "node_modules/acorn": {
@@ -2076,6 +2086,15 @@
         "node": ">= 16"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2170,7 +2189,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -2789,6 +2808,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-user-locale": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-2.3.2.tgz",
+      "integrity": "sha512-O2GWvQkhnbDoWFUJfaBlDIKUEdND8ATpBXD6KXcbhxlfktyD/d8w6mkzM/IlQEqGZAMz/PW6j6Hv53BiigKLUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mem": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3022,7 +3053,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3180,6 +3210,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
@@ -3218,6 +3260,18 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-defer": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3226,6 +3280,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mem": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+      "license": "MIT",
+      "dependencies": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/mem?sponsor=1"
       }
     },
     "node_modules/mime-db": {
@@ -3249,6 +3319,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/min-indent": {
@@ -3321,6 +3400,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3337,6 +3425,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/p-limit": {
@@ -3523,6 +3620,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -3560,6 +3674,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-calendar": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-4.8.0.tgz",
+      "integrity": "sha512-qFgwo+p58sgv1QYMI1oGNaop90eJVKuHTZ3ZgBfrrpUb+9cAexxsKat0sAszgsizPMVo7vOXedV7Lqa0GQGMvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@wojtekmaj/date-utils": "^1.1.3",
+        "clsx": "^2.0.0",
+        "get-user-locale": "^2.2.1",
+        "prop-types": "^15.6.0",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-chartjs-2": {
@@ -4183,6 +4323,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/frontend/react-app/package.json
+++ b/frontend/react-app/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "chart.js": "^4.5.0",
     "react": "^19.1.0",
+    "react-calendar": "^4.8.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0"
   },

--- a/frontend/react-app/src/App.css
+++ b/frontend/react-app/src/App.css
@@ -27,3 +27,17 @@ ul {
   margin-left: 2rem;
   max-width: 300px;
 }
+
+.calendar-panel {
+  margin-right: 2rem;
+}
+
+.calendar-panel .has-data {
+  background: #4fc3f7;
+  color: #111;
+}
+
+.daily-summary {
+  list-style: none;
+  padding: 0;
+}

--- a/frontend/react-app/src/App.jsx
+++ b/frontend/react-app/src/App.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Line } from 'react-chartjs-2'
 import { Chart, LineElement, PointElement, LinearScale, CategoryScale, Filler } from 'chart.js'
 import InsightsPanel from './InsightsPanel'
+import CalendarPanel from './CalendarPanel'
 import './App.css'
 
 Chart.register(LineElement, PointElement, LinearScale, CategoryScale, Filler)
@@ -9,6 +10,7 @@ Chart.register(LineElement, PointElement, LinearScale, CategoryScale, Filler)
 function App() {
   const [summary, setSummary] = useState(null)
   const [weekly, setWeekly] = useState(null)
+  const [history, setHistory] = useState(null)
   const [error, setError] = useState(null)
 
   useEffect(() => {
@@ -36,36 +38,51 @@ function App() {
         console.error(err)
         setError(err.message)
       })
+    fetch('/api/history?days=30')
+      .then(async res => {
+        if (!res.ok) {
+          throw new Error(await res.text())
+        }
+        return res.json()
+      })
+      .then(setHistory)
+      .catch(err => {
+        console.error(err)
+        setError(err.message)
+      })
   }, [])
 
   if (error) return <p role="alert">Error: {error}</p>
-  if (!summary || !weekly) return <p>Loading...</p>
+  if (!summary || !weekly || !history) return <p>Loading...</p>
 
   return (
     <div className="dashboard">
-      <h1>Garmin Dashboard</h1>
-      <ul>
-        <li><strong>Steps:</strong> {summary.steps}</li>
-        <li><strong>Resting HR:</strong> {summary.resting_hr}</li>
-        <li><strong>VO2 Max:</strong> {summary.vo2max}</li>
-        <li><strong>Sleep:</strong> {summary.sleep_hours} hrs</li>
-      </ul>
-      
-      <div className="chart-container">
-        <Line
-          data={{
-            labels: weekly.map(d => new Date(d.time).toLocaleDateString()),
-            datasets: [{
-              label: 'Steps',
-              data: weekly.map(d => d.steps),
-              fill: true,
-              backgroundColor: 'rgba(40,167,69,0.1)',
-              borderColor: 'rgba(40,167,69,1)',
-              tension: 0.3,
-            }],
-          }}
-          options={{ responsive: true, scales: { y: { beginAtZero: true } } }}
-        />
+      <CalendarPanel history={history} />
+      <div>
+        <h1>Garmin Dashboard</h1>
+        <ul>
+          <li><strong>Steps:</strong> {summary.steps}</li>
+          <li><strong>Resting HR:</strong> {summary.resting_hr}</li>
+          <li><strong>VO2 Max:</strong> {summary.vo2max}</li>
+          <li><strong>Sleep:</strong> {summary.sleep_hours} hrs</li>
+        </ul>
+
+        <div className="chart-container">
+          <Line
+            data={{
+              labels: weekly.map(d => new Date(d.time).toLocaleDateString()),
+              datasets: [{
+                label: 'Steps',
+                data: weekly.map(d => d.steps),
+                fill: true,
+                backgroundColor: 'rgba(40,167,69,0.1)',
+                borderColor: 'rgba(40,167,69,1)',
+                tension: 0.3,
+              }],
+            }}
+            options={{ responsive: true, scales: { y: { beginAtZero: true } } }}
+          />
+        </div>
       </div>
       <InsightsPanel weekly={weekly} />
     </div>

--- a/frontend/react-app/src/App.test.jsx
+++ b/frontend/react-app/src/App.test.jsx
@@ -3,6 +3,7 @@ import App from './App';
 import { vi, describe, it, expect } from 'vitest';
 
 vi.mock('react-chartjs-2', () => ({ Line: () => <div>Chart</div> }));
+vi.mock('react-calendar', () => ({ default: () => <div>Calendar</div> }));
 
 describe('App', () => {
   it('renders data from API', async () => {
@@ -19,6 +20,7 @@ describe('App', () => {
       vo2max: 50,
       sleep_hours: 8,
     }];
+    const history = weekly
     global.fetch = vi.fn()
       .mockResolvedValueOnce({
         ok: true,
@@ -29,6 +31,11 @@ describe('App', () => {
         ok: true,
         json: () => Promise.resolve(weekly),
         text: () => Promise.resolve('')
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(history),
+        text: () => Promise.resolve('')
       });
     render(<App />);
     await screen.findByText('100');
@@ -38,6 +45,11 @@ describe('App', () => {
   it('shows error message if fetch fails', async () => {
     global.fetch = vi.fn()
       .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([]),
+        text: () => Promise.resolve('')
+      })
       .mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve([]),

--- a/frontend/react-app/src/CalendarPanel.jsx
+++ b/frontend/react-app/src/CalendarPanel.jsx
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+import Calendar from 'react-calendar'
+import 'react-calendar/dist/Calendar.css'
+
+export default function CalendarPanel({ history }) {
+  const [value, setValue] = useState(null)
+
+  if (!history?.length) return null
+
+  const dataMap = new Map(
+    history.map(h => [new Date(h.time).toDateString(), h])
+  )
+
+  const tileClassName = ({ date, view }) => {
+    if (view === 'month' && dataMap.has(date.toDateString())) {
+      return 'has-data'
+    }
+  }
+
+  const selected = value && dataMap.get(value.toDateString())
+
+  return (
+    <div className="calendar-panel">
+      <Calendar onChange={setValue} tileClassName={tileClassName} value={value} />
+      {selected && (
+        <ul className="daily-summary">
+          <li><strong>Steps:</strong> {selected.steps}</li>
+          <li><strong>Resting HR:</strong> {selected.resting_hr}</li>
+          <li><strong>VO2 Max:</strong> {selected.vo2max}</li>
+          <li><strong>Sleep:</strong> {selected.sleep_hours} hrs</li>
+        </ul>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `fetchHistory` and `/api/history` endpoint
- add calendar panel component in React
- fetch 30 days of history for the calendar
- update tests for new endpoint and new component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68814a06897c8324835976c9d183c4d9