### PR TITLE
Add recent activities dropdown

### DIFF
--- a/api/scraper.js
+++ b/api/scraper.js
@@ -90,8 +90,6 @@ async function fetchWeeklySummary() {
   return fetchHistory(7);
 }
 
-module.exports = { fetchGarminSummary, fetchWeeklySummary, fetchHistory };
-
 async function fetchActivityRoute(activityId) {
   await login();
   const gpx = await gcClient.client.get(
@@ -107,6 +105,20 @@ async function fetchActivityRoute(activityId) {
   }));
   return points;
 }
+async function fetchRecentActivities(limit = 10) {
+  await login();
+  const acts = await gcClient.getActivities(0, limit);
+  return acts.map(a => ({
+    id: String(a.activityId),
+    name: a.activityName || `Activity ${a.activityId}`,
+  }));
+}
 
-module.exports = { fetchGarminSummary, fetchWeeklySummary, fetchActivityRoute };
+module.exports = {
+  fetchGarminSummary,
+  fetchWeeklySummary,
+  fetchHistory,
+  fetchActivityRoute,
+  fetchRecentActivities,
+};
 

--- a/frontend/react-app/src/App.jsx
+++ b/frontend/react-app/src/App.jsx
@@ -20,6 +20,7 @@ function App() {
   const [history, setHistory] = useState(null)
 
   const [route, setRoute] = useState(null)
+  const [activities, setActivities] = useState([])
   const [activityId, setActivityId] = useState('')
 
   const [error, setError] = useState(null)
@@ -57,6 +58,16 @@ function App() {
         return res.json()
       })
       .then(setHistory)
+      .catch(err => {
+        console.error(err)
+        setError(err.message)
+      })
+    fetch('/api/activities')
+      .then(res => res.json())
+      .then(data => {
+        setActivities(data)
+        if (data.length) setActivityId(data[0].id)
+      })
       .catch(err => {
         console.error(err)
         setError(err.message)
@@ -109,11 +120,19 @@ function App() {
 
 
       <div className="route-loader">
-        <input
-          value={activityId}
-          onChange={e => setActivityId(e.target.value)}
-          placeholder="Activity ID"
-        />
+        {activities.length ? (
+          <select value={activityId} onChange={e => setActivityId(e.target.value)}>
+            {activities.map(a => (
+              <option key={a.id} value={a.id}>{a.name}</option>
+            ))}
+          </select>
+        ) : (
+          <input
+            value={activityId}
+            onChange={e => setActivityId(e.target.value)}
+            placeholder="Activity ID"
+          />
+        )}
         <button onClick={loadRoute}>Load Route</button>
       </div>
 

--- a/frontend/react-app/src/App.test.jsx
+++ b/frontend/react-app/src/App.test.jsx
@@ -44,6 +44,11 @@ describe('App', () => {
         ok: true,
         json: () => Promise.resolve(history),
         text: () => Promise.resolve('')
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([{ id: '1', name: 'Run' }]),
+        text: () => Promise.resolve('')
       });
     render(<App />);
     await screen.findByText('100');
@@ -53,6 +58,11 @@ describe('App', () => {
   it('shows error message if fetch fails', async () => {
     global.fetch = vi.fn()
       .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([]),
+        text: () => Promise.resolve('')
+      })
       .mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve([]),


### PR DESCRIPTION
## Summary
- clean up API routes and add `/api/activities`
- expose `fetchRecentActivities` in scraper
- update React app to show dropdown of last activities
- update tests for new endpoint and component behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68814ad7b11c83249f8b7960d7b8a2b1