### PR TITLE
Add metrics comparison panel

### DIFF
--- a/frontend/react-app/src/App.css
+++ b/frontend/react-app/src/App.css
@@ -41,3 +41,11 @@ ul {
   list-style: none;
   padding: 0;
 }
+
+.compare-panel {
+  margin-top: 2rem;
+}
+
+.compare-panel .selectors {
+  margin-bottom: 1rem;
+}

--- a/frontend/react-app/src/App.jsx
+++ b/frontend/react-app/src/App.jsx
@@ -5,6 +5,7 @@ import { Chart, LineElement, PointElement, LinearScale, CategoryScale, Filler } 
 import RouteMap from './RouteMap.jsx'
 
 import InsightsPanel from './InsightsPanel'
+import ComparePanel from './ComparePanel'
 
 import CalendarPanel from './CalendarPanel'
 
@@ -138,7 +139,9 @@ function App() {
 
       <RouteMap points={route} />
 
+
       <InsightsPanel weekly={weekly} />
+      <ComparePanel history={history} />
 
     </div>
   )

--- a/frontend/react-app/src/App.test.jsx
+++ b/frontend/react-app/src/App.test.jsx
@@ -53,6 +53,7 @@ describe('App', () => {
     render(<App />);
     await screen.findByText('100');
     await screen.findByText(/Insights/);
+    await screen.findByText(/Compare Metrics/);
   });
 
   it('shows error message if fetch fails', async () => {

--- a/frontend/react-app/src/ComparePanel.jsx
+++ b/frontend/react-app/src/ComparePanel.jsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+import { Line } from 'react-chartjs-2'
+import { Chart, LineElement, PointElement, LinearScale, CategoryScale, Filler } from 'chart.js'
+
+Chart.register(LineElement, PointElement, LinearScale, CategoryScale, Filler)
+
+const fields = [
+  { key: 'steps', label: 'Steps' },
+  { key: 'resting_hr', label: 'Resting HR' },
+  { key: 'vo2max', label: 'VO2 Max' },
+  { key: 'sleep_hours', label: 'Sleep (hrs)' }
+]
+
+export default function ComparePanel({ history }) {
+  const [first, setFirst] = useState(fields[0].key)
+  const [second, setSecond] = useState(fields[1].key)
+
+  if (!history?.length) return null
+
+  const labels = history.map(d => new Date(d.time).toLocaleDateString())
+
+  const dataset = key => history.map(d => d[key])
+
+  return (
+    <div className="compare-panel">
+      <h2>Compare Metrics</h2>
+      <div className="selectors">
+        <select value={first} onChange={e => setFirst(e.target.value)}>
+          {fields.map(f => (
+            <option key={f.key} value={f.key}>{f.label}</option>
+          ))}
+        </select>
+        <select value={second} onChange={e => setSecond(e.target.value)}>
+          {fields.map(f => (
+            <option key={f.key} value={f.key}>{f.label}</option>
+          ))}
+        </select>
+      </div>
+      <div className="chart-container">
+        <Line
+          data={{
+            labels,
+            datasets: [
+              {
+                label: fields.find(f => f.key === first).label,
+                data: dataset(first),
+                borderColor: 'rgba(255,159,64,1)',
+                backgroundColor: 'rgba(255,159,64,0.1)',
+                tension: 0.3,
+                fill: true,
+              },
+              {
+                label: fields.find(f => f.key === second).label,
+                data: dataset(second),
+                borderColor: 'rgba(75,192,192,1)',
+                backgroundColor: 'rgba(75,192,192,0.1)',
+                tension: 0.3,
+                fill: true,
+              },
+            ],
+          }}
+          options={{ responsive: true, scales: { y: { beginAtZero: true } } }}
+        />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `ComparePanel` component with selectable metrics
- render new panel in the dashboard
- style compare panel in CSS
- extend tests to check for the new section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68815c3f510483249b271e70063b40f6