### PR TITLE
Add limit query for /api/activities

### DIFF
--- a/api/__tests__/index.test.js
+++ b/api/__tests__/index.test.js
@@ -69,6 +69,13 @@ describe('GET /api/activities', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual([{ id: '1', name: 'Run' }]);
   });
+
+  it('passes limit query parameter', async () => {
+    fetchRecentActivities.mockResolvedValue([]);
+    const res = await request(app).get('/api/activities?limit=5');
+    expect(res.status).toBe(200);
+    expect(fetchRecentActivities).toHaveBeenCalledWith(5);
+  });
 });
 
 describe('Unknown routes', () => {

--- a/api/__tests__/scraper.test.js
+++ b/api/__tests__/scraper.test.js
@@ -111,8 +111,16 @@ describe('fetchRecentActivities', () => {
     );
     process.env.GARMIN_COOKIE_PATH = cookiePath;
     gcClient.getActivities = jest.fn().mockResolvedValue([
-      { activityId: 1, activityName: 'Run' },
-      { activityId: 2, activityName: 'Ride' },
+      {
+        activityId: 1,
+        activityName: 'Run',
+        startTimeLocal: '2024-01-01T00:00:00',
+      },
+      {
+        activityId: 2,
+        activityName: 'Ride',
+        startTimeLocal: '2024-01-02T00:00:00',
+      },
     ]);
   });
 
@@ -128,9 +136,14 @@ describe('fetchRecentActivities', () => {
   it('returns simplified activity list', async () => {
     const acts = await fetchRecentActivities();
     expect(acts).toEqual([
-      { id: '1', name: 'Run' },
-      { id: '2', name: 'Ride' },
+      { id: '1', name: 'Run', date: '2024-01-01T00:00:00' },
+      { id: '2', name: 'Ride', date: '2024-01-02T00:00:00' },
     ]);
     expect(gcClient.getActivities).toHaveBeenCalledWith(0, 10);
+  });
+
+  it('uses provided limit', async () => {
+    await fetchRecentActivities(5);
+    expect(gcClient.getActivities).toHaveBeenCalledWith(0, 5);
   });
 });

--- a/api/index.js
+++ b/api/index.js
@@ -54,8 +54,9 @@ app.get('/api/history', async (req, res) => {
 });
 
 app.get('/api/activities', async (req, res) => {
+  const limit = req.query.limit ? parseInt(req.query.limit, 10) : undefined;
   try {
-    const acts = await fetchRecentActivities();
+    const acts = await fetchRecentActivities(limit);
     res.json(acts);
   } catch (err) {
     console.error(err);

--- a/api/scraper.js
+++ b/api/scraper.js
@@ -111,6 +111,7 @@ async function fetchRecentActivities(limit = 10) {
   return acts.map(a => ({
     id: String(a.activityId),
     name: a.activityName || `Activity ${a.activityId}`,
+    date: a.startTimeLocal || a.startTime || null,
   }));
 }
 

--- a/frontend/react-app/src/App.jsx
+++ b/frontend/react-app/src/App.jsx
@@ -24,6 +24,7 @@ function App() {
   const [route, setRoute] = useState(null)
   const [activities, setActivities] = useState([])
   const [activityId, setActivityId] = useState('')
+  const [activityLimit] = useState(20)
 
   const [error, setError] = useState(null)
 
@@ -64,7 +65,7 @@ function App() {
         console.error(err)
         setError(err.message)
       })
-    fetch('/api/activities')
+    fetch(`/api/activities?limit=${activityLimit}`)
       .then(res => res.json())
       .then(data => {
         setActivities(data)
@@ -125,7 +126,9 @@ function App() {
         {activities.length ? (
           <select value={activityId} onChange={e => setActivityId(e.target.value)}>
             {activities.map(a => (
-              <option key={a.id} value={a.id}>{a.name}</option>
+              <option key={a.id} value={a.id}>
+                {a.name} - {a.date ? new Date(a.date).toLocaleDateString() : ''}
+              </option>
             ))}
           </select>
         ) : (


### PR DESCRIPTION
## Summary
- allow `/api/activities` to accept a `limit` query parameter
- expose start date in `fetchRecentActivities`
- show activity date in the React dropdown and request 20 activities
- test the new limit parameter for the API routes and scraper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688161a10fb08324bd64d0164507d6ec