### PR TITLE
Implement new DashboardPage layout

### DIFF
--- a/frontend/react-app/index.html
+++ b/frontend/react-app/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
   </head>
-  <body>
+  <body class="bg-background text-foreground">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/frontend/react-app/src/App.jsx
+++ b/frontend/react-app/src/App.jsx
@@ -1,4 +1,4 @@
-import DashboardPage from './DashboardPage'
+import DashboardPage from '@/pages/DashboardPage'
 
 export default function App() {
   return <DashboardPage />

--- a/frontend/react-app/src/components/ui/card.jsx
+++ b/frontend/react-app/src/components/ui/card.jsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { cn } from '../../lib/utils'
+
+export function Card({ className, ...props }) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export function CardHeader({ className, ...props }) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export function CardTitle({ className, ...props }) {
+  return (
+    <div data-slot="card-title" className={cn('leading-none font-semibold', className)} {...props} />
+  )
+}
+
+export function CardDescription({ className, ...props }) {
+  return (
+    <div data-slot="card-description" className={cn('text-muted-foreground text-sm', className)} {...props} />
+  )
+}
+
+export function CardAction({ className, ...props }) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', className)}
+      {...props}
+    />
+  )
+}
+
+export function CardContent({ className, ...props }) {
+  return (
+    <div data-slot="card-content" className={cn('px-6', className)} {...props} />
+  )
+}
+
+export function CardFooter({ className, ...props }) {
+  return (
+    <div data-slot="card-footer" className={cn('flex items-center px-6 [.border-t]:pt-6', className)} {...props} />
+  )
+}
+

--- a/frontend/react-app/src/index.css
+++ b/frontend/react-app/src/index.css
@@ -3,70 +3,12 @@
 @tailwind utilities;
 
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  --background: 0 0% 100%;
+  --foreground: 222.2 84% 4.9%;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+.dark {
+  --background: 222.2 84% 4.9%;
+  --foreground: 210 40% 98%;
 }
 
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}

--- a/frontend/react-app/src/pages/DashboardPage.tsx
+++ b/frontend/react-app/src/pages/DashboardPage.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react'
+import { Card } from '@/components/ui/card'
+import CalendarPanel from '@/CalendarPanel'
+import InsightsPanel from '@/InsightsPanel'
+import ComparePanel from '@/ComparePanel'
+import { Button } from '@/components/ui/button'
+
+export default function DashboardPage() {
+  const [summary, setSummary] = useState<any>(null)
+  const [weekly, setWeekly] = useState<any>(null)
+  const [history, setHistory] = useState<any>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function loadData() {
+    try {
+      const [sRes, wRes, hRes] = await Promise.all([
+        fetch('/api/summary'),
+        fetch('/api/weekly'),
+        fetch('/api/history?days=30'),
+      ])
+      if (!sRes.ok) throw new Error(await sRes.text())
+      if (!wRes.ok) throw new Error(await wRes.text())
+      if (!hRes.ok) throw new Error(await hRes.text())
+      const [sData, wData, hData] = await Promise.all([
+        sRes.json(),
+        wRes.json(),
+        hRes.json(),
+      ])
+      setSummary(sData)
+      setWeekly(wData)
+      setHistory(hData)
+      setError(null)
+    } catch (err: any) {
+      console.error(err)
+      setError(err.message)
+    }
+  }
+
+  useEffect(() => {
+    loadData()
+  }, [])
+
+  if (error) return <p role="alert">Error: {error}</p>
+  if (!summary || !weekly || !history) return <p>Loading...</p>
+
+  return (
+    <main className="p-4 bg-background min-h-screen text-foreground">
+      <h1 className="text-2xl font-bold mb-4">Garmin Dashboard</h1>
+
+      <section className="mb-6">
+        <CalendarPanel history={history} />
+      </section>
+
+      <section className="grid md:grid-cols-2 gap-4 mb-6">
+        <Card className="p-4">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-xl font-semibold">Key Metrics</h2>
+            <Button size="sm" onClick={loadData}>Reload</Button>
+          </div>
+          <ul className="grid grid-cols-2 gap-2">
+            <li><strong>Steps:</strong> {summary.steps}</li>
+            <li><strong>Resting HR:</strong> {summary.resting_hr}</li>
+            <li><strong>VO2 Max:</strong> {summary.vo2max}</li>
+            <li><strong>Sleep:</strong> {summary.sleep_hours} hrs</li>
+          </ul>
+        </Card>
+        <InsightsPanel weekly={weekly} />
+      </section>
+
+      <section className="mb-6">
+        <ComparePanel history={history} />
+      </section>
+    </main>
+  )
+}
+

--- a/frontend/react-app/tailwind.config.js
+++ b/frontend/react-app/tailwind.config.js
@@ -1,7 +1,12 @@
 export default {
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+      },
+    },
   },
   plugins: [],
 }

--- a/frontend/react-app/vite.config.js
+++ b/frontend/react-app/vite.config.js
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   server: {
     proxy: {
       '/api': 'http://localhost:3002',


### PR DESCRIPTION
## Summary
- add UI card component
- build a new `DashboardPage.tsx` page
- use DashboardPage as the main app view
- clean up global styling and Tailwind config
- configure Vite alias for `@`

## Testing
- `npm test --prefix api && npm test --prefix frontend/react-app`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68817bd90ab48324bf3d68ffc5c16f08