### PR TITLE
Replace Chart.js with Recharts

### DIFF
--- a/frontend/react-app/setupTests.js
+++ b/frontend/react-app/setupTests.js
@@ -2,3 +2,10 @@
 import { expect } from 'vitest';
 global.expect = expect;
 await import('@testing-library/jest-dom');
+
+// Polyfill for recharts ResponsiveContainer
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};

--- a/frontend/react-app/src/App.test.jsx
+++ b/frontend/react-app/src/App.test.jsx
@@ -1,9 +1,8 @@
 /* global global */
 import { render, screen } from '@testing-library/react';
-import App from './App';
 import { vi as viFn, describe, it, expect } from 'vitest';
 
-viFn.mock('react-chartjs-2', () => ({ Line: () => <div>Chart</div> }));
+import App from './App';
 
 viFn.mock('react-calendar', () => ({ default: () => <div>Calendar</div> }));
 

--- a/frontend/react-app/src/ComparePanel.jsx
+++ b/frontend/react-app/src/ComparePanel.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
-import { Line } from 'react-chartjs-2'
-import { Chart, LineElement, PointElement, LinearScale, CategoryScale, Filler } from 'chart.js'
+import CompareMetricsChart from '@/components/charts/CompareMetricsChart'
+import { Card, CardHeader, CardContent, CardTitle } from '@/components/ui/card'
 
 import {
   Select,
@@ -10,7 +10,6 @@ import {
   SelectItem,
 } from './components/ui/select'
 
-Chart.register(LineElement, PointElement, LinearScale, CategoryScale, Filler)
 
 const fields = [
   { key: 'steps', label: 'Steps' },
@@ -25,65 +24,53 @@ export default function ComparePanel({ history }) {
 
   if (!history?.length) return null
 
-  const labels = history.map(d => new Date(d.time).toLocaleDateString())
-
-  const dataset = key => history.map(d => d[key])
+  const data = history.map(d => ({
+    date: new Date(d.time).toLocaleDateString(),
+    ...d,
+  }))
 
   return (
-    <div className="compare-panel">
-      <h2>Compare Metrics</h2>
-      <div className="selectors">
-        <Select value={first} onValueChange={setFirst}>
-          <SelectTrigger>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {fields.map(f => (
-              <SelectItem key={f.key} value={f.key}>
-                {f.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Select value={second} onValueChange={setSecond}>
-          <SelectTrigger>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {fields.map(f => (
-              <SelectItem key={f.key} value={f.key}>
-                {f.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="chart-container">
-        <Line
-          data={{
-            labels,
-            datasets: [
-              {
-                label: fields.find(f => f.key === first).label,
-                data: dataset(first),
-                borderColor: 'rgba(255,159,64,1)',
-                backgroundColor: 'rgba(255,159,64,0.1)',
-                tension: 0.3,
-                fill: true,
-              },
-              {
-                label: fields.find(f => f.key === second).label,
-                data: dataset(second),
-                borderColor: 'rgba(75,192,192,1)',
-                backgroundColor: 'rgba(75,192,192,0.1)',
-                tension: 0.3,
-                fill: true,
-              },
-            ],
-          }}
-          options={{ responsive: true, scales: { y: { beginAtZero: true } } }}
-        />
-      </div>
-    </div>
+    <Card className="compare-panel">
+      <CardHeader>
+        <CardTitle>Compare Metrics</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="selectors flex gap-2">
+          <Select value={first} onValueChange={setFirst}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {fields.map(f => (
+                <SelectItem key={f.key} value={f.key}>
+                  {f.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={second} onValueChange={setSecond}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {fields.map(f => (
+                <SelectItem key={f.key} value={f.key}>
+                  {f.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="chart-container">
+          <CompareMetricsChart
+            data={data}
+            first={first}
+            second={second}
+            firstLabel={fields.find(f => f.key === first).label}
+            secondLabel={fields.find(f => f.key === second).label}
+          />
+        </div>
+      </CardContent>
+    </Card>
   )
 }

--- a/frontend/react-app/src/InsightsPanel.jsx
+++ b/frontend/react-app/src/InsightsPanel.jsx
@@ -1,7 +1,13 @@
-import { Line } from 'react-chartjs-2'
-import { Chart, LineElement, PointElement, LinearScale, CategoryScale, Filler } from 'chart.js'
-
-Chart.register(LineElement, PointElement, LinearScale, CategoryScale, Filler)
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+} from '@/components/ui/card'
+import StepsChart from '@/components/charts/StepsChart'
+import RestingHRChart from '@/components/charts/RestingHRChart'
+import Vo2MaxChart from '@/components/charts/Vo2MaxChart'
+import SleepChart from '@/components/charts/SleepChart'
 
 function movingAverage(data, window) {
   return data.map((_, idx) => {
@@ -15,92 +21,45 @@ function movingAverage(data, window) {
 export default function InsightsPanel({ weekly }) {
   if (!weekly?.length) return null
 
-  const labels = weekly.map(d => new Date(d.time).toLocaleDateString())
-  const sleep = weekly.map(d => d.sleep_hours)
-  const resting = weekly.map(d => d.resting_hr)
-  const vo2 = weekly.map(d => d.vo2max)
-  const steps = weekly.map(d => d.steps)
-  const intensity = steps.map(s => s / 100)
+  const data = weekly.map(d => ({
+    date: new Date(d.time).toLocaleDateString(),
+    ...d,
+    intensity: d.steps / 100,
+  }))
 
-  const restMA = movingAverage(resting, 3)
-  const vo2MA = movingAverage(vo2, 3)
+  const restMA = movingAverage(data.map(d => d.resting_hr), 3)
+  const vo2MA = movingAverage(data.map(d => d.vo2max), 3)
+  const sleepMA = movingAverage(data.map(d => d.sleep_hours), 3)
 
-  const meanSteps = steps.reduce((a, b) => a + b, 0) / steps.length
-  const meanInt = intensity.reduce((a, b) => a + b, 0) / intensity.length
-  const num = steps.reduce((sum, s, i) => sum + (s - meanSteps) * (intensity[i] - meanInt), 0)
+  data.forEach((d, i) => {
+    d.resting_hr_ma = restMA[i]
+    d.vo2max_ma = vo2MA[i]
+    d.sleep_hours_ma = sleepMA[i]
+  })
+
+  const meanSteps = data.reduce((a, b) => a + b.steps, 0) / data.length
+  const meanInt = data.reduce((a, b) => a + b.intensity, 0) / data.length
+  const num = data.reduce(
+    (sum, d) => sum + (d.steps - meanSteps) * (d.intensity - meanInt),
+    0
+  )
   const denom = Math.sqrt(
-    steps.reduce((sum, s) => sum + (s - meanSteps) ** 2, 0) *
-      intensity.reduce((sum, x) => sum + (x - meanInt) ** 2, 0)
+    data.reduce((s, d) => s + (d.steps - meanSteps) ** 2, 0) *
+      data.reduce((s, d) => s + (d.intensity - meanInt) ** 2, 0)
   )
   const corr = denom ? num / denom : 0
 
   return (
-    <aside className="insights">
-      <h2>Insights</h2>
-      <div className="chart-container">
-        <Line
-          data={{
-            labels,
-            datasets: [
-              {
-                label: 'Sleep (hrs)',
-                data: movingAverage(sleep, 3),
-                borderColor: 'rgba(255,99,132,1)',
-                backgroundColor: 'rgba(255,99,132,0.1)',
-                tension: 0.3,
-                fill: true,
-              },
-              {
-                label: 'Resting HR',
-                data: restMA,
-                borderColor: 'rgba(54,162,235,1)',
-                backgroundColor: 'rgba(54,162,235,0.1)',
-                tension: 0.3,
-                fill: true,
-              },
-            ],
-          }}
-          options={{ responsive: true, scales: { y: { beginAtZero: true } } }}
-        />
-      </div>
-      <p>Steps vs intensity minutes correlation: {corr.toFixed(2)}</p>
-      <div className="chart-container">
-        <Line
-          data={{
-            labels,
-            datasets: [
-              {
-                label: 'Resting HR MA',
-                data: restMA,
-                borderColor: 'rgba(75,192,192,1)',
-                backgroundColor: 'rgba(75,192,192,0.1)',
-                tension: 0.3,
-                fill: true,
-              },
-            ],
-          }}
-          options={{ responsive: true, scales: { y: { beginAtZero: true } } }}
-        />
-      </div>
-      <div className="chart-container">
-        <Line
-          data={{
-            labels,
-            datasets: [
-              {
-                label: 'VO2 Max MA',
-                data: vo2MA,
-                borderColor: 'rgba(153,102,255,1)',
-                backgroundColor: 'rgba(153,102,255,0.1)',
-                tension: 0.3,
-                fill: true,
-              },
-            ],
-          }}
-          options={{ responsive: true, scales: { y: { beginAtZero: true } } }}
-        />
-      </div>
-    </aside>
+    <Card className="insights">
+      <CardHeader>
+        <CardTitle>Insights</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <SleepChart data={data.map(d => ({ date: d.date, sleep_hours: d.sleep_hours_ma }))} />
+        <RestingHRChart data={data.map(d => ({ date: d.date, resting_hr: d.resting_hr_ma }))} />
+        <Vo2MaxChart data={data.map(d => ({ date: d.date, vo2max: d.vo2max_ma }))} />
+        <p>Steps vs intensity minutes correlation: {corr.toFixed(2)}</p>
+      </CardContent>
+    </Card>
   )
 }
-

--- a/frontend/react-app/src/components/charts/CompareMetricsChart.tsx
+++ b/frontend/react-app/src/components/charts/CompareMetricsChart.tsx
@@ -1,0 +1,45 @@
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts'
+
+export interface CompareDatum {
+  date: string
+  [key: string]: number | string
+}
+
+interface Props {
+  data: CompareDatum[]
+  first: string
+  second: string
+  firstLabel: string
+  secondLabel: string
+}
+
+export default function CompareMetricsChart({
+  data,
+  first,
+  second,
+  firstLabel,
+  secondLabel,
+}: Props) {
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <LineChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="date" />
+        <YAxis />
+        <Tooltip />
+        <Legend />
+        <Line type="monotone" dataKey={first} name={firstLabel} stroke="#f97316" />
+        <Line type="monotone" dataKey={second} name={secondLabel} stroke="#10b981" />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/frontend/react-app/src/components/charts/RestingHRChart.tsx
+++ b/frontend/react-app/src/components/charts/RestingHRChart.tsx
@@ -1,0 +1,28 @@
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
+
+export interface HRDatum {
+  date: string
+  resting_hr: number
+}
+
+export default function RestingHRChart({ data }: { data: HRDatum[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <LineChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="date" />
+        <YAxis />
+        <Tooltip />
+        <Line type="monotone" dataKey="resting_hr" stroke="#ef4444" />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/frontend/react-app/src/components/charts/SleepChart.tsx
+++ b/frontend/react-app/src/components/charts/SleepChart.tsx
@@ -1,0 +1,40 @@
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
+
+export interface SleepDatum {
+  date: string
+  sleep_hours: number
+}
+
+export default function SleepChart({ data }: { data: SleepDatum[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <AreaChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+        <defs>
+          <linearGradient id="sleepColor" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="#10b981" stopOpacity={0.8} />
+            <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="date" />
+        <YAxis />
+        <Tooltip />
+        <Area
+          type="monotone"
+          dataKey="sleep_hours"
+          stroke="#10b981"
+          fillOpacity={1}
+          fill="url(#sleepColor)"
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  )
+}

--- a/frontend/react-app/src/components/charts/StepsChart.tsx
+++ b/frontend/react-app/src/components/charts/StepsChart.tsx
@@ -1,0 +1,40 @@
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
+
+export interface StepsDatum {
+  date: string
+  steps: number
+}
+
+export default function StepsChart({ data }: { data: StepsDatum[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <AreaChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+        <defs>
+          <linearGradient id="stepsColor" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.8} />
+            <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="date" />
+        <YAxis />
+        <Tooltip />
+        <Area
+          type="monotone"
+          dataKey="steps"
+          stroke="#3b82f6"
+          fillOpacity={1}
+          fill="url(#stepsColor)"
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  )
+}

--- a/frontend/react-app/src/components/charts/Vo2MaxChart.tsx
+++ b/frontend/react-app/src/components/charts/Vo2MaxChart.tsx
@@ -1,0 +1,28 @@
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
+
+export interface Vo2Datum {
+  date: string
+  vo2max: number
+}
+
+export default function Vo2MaxChart({ data }: { data: Vo2Datum[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <LineChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="date" />
+        <YAxis />
+        <Tooltip />
+        <Line type="monotone" dataKey="vo2max" stroke="#8b5cf6" />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/frontend/react-app/src/pages/DashboardPage.tsx
+++ b/frontend/react-app/src/pages/DashboardPage.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useState } from 'react'
-import { Card } from '@/components/ui/card'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import CalendarPanel from '@/CalendarPanel'
 import InsightsPanel from '@/InsightsPanel'
 import ComparePanel from '@/ComparePanel'
 import { Button } from '@/components/ui/button'
+import StepsChart from '@/components/charts/StepsChart'
+import RestingHRChart from '@/components/charts/RestingHRChart'
+import Vo2MaxChart from '@/components/charts/Vo2MaxChart'
+import SleepChart from '@/components/charts/SleepChart'
 
 export default function DashboardPage() {
   const [summary, setSummary] = useState<any>(null)
@@ -65,6 +69,41 @@ export default function DashboardPage() {
           </ul>
         </Card>
         <InsightsPanel weekly={weekly} />
+      </section>
+
+      <section className="grid md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Daily Steps</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <StepsChart data={weekly.map(d => ({ date: new Date(d.time).toLocaleDateString(), steps: d.steps }))} />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Resting HR</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <RestingHRChart data={weekly.map(d => ({ date: new Date(d.time).toLocaleDateString(), resting_hr: d.resting_hr }))} />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>VO2 Max</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Vo2MaxChart data={weekly.map(d => ({ date: new Date(d.time).toLocaleDateString(), vo2max: d.vo2max }))} />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Sleep Duration</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <SleepChart data={weekly.map(d => ({ date: new Date(d.time).toLocaleDateString(), sleep_hours: d.sleep_hours }))} />
+          </CardContent>
+        </Card>
       </section>
 
       <section className="mb-6">


### PR DESCRIPTION
## Summary
- add new Recharts chart components
- refactor ComparePanel and InsightsPanel to use Recharts
- display individual metric charts on the dashboard
- update tests with ResizeObserver polyfill

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68817e35ddd48324b8252f062f495c05