### PR TITLE
Clean up dashboard imports

### DIFF
--- a/frontend/react-app/src/pages/DashboardPage.tsx
+++ b/frontend/react-app/src/pages/DashboardPage.tsx
@@ -2,16 +2,10 @@ import { useEffect, useState } from 'react'
 
 import { Card, CardHeader, CardContent } from '@/components/ui/card'
 
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
-
 import CalendarPanel from '@/CalendarPanel'
 import InsightsPanel from '@/InsightsPanel'
 import ComparePanel from '@/ComparePanel'
 import { Button } from '@/components/ui/button'
-import StepsChart from '@/components/charts/StepsChart'
-import RestingHRChart from '@/components/charts/RestingHRChart'
-import Vo2MaxChart from '@/components/charts/Vo2MaxChart'
-import SleepChart from '@/components/charts/SleepChart'
 
 export default function DashboardPage() {
   const [summary, setSummary] = useState<any>(null)


### PR DESCRIPTION
## Summary
- remove unused chart components in `DashboardPage`
- deduplicate `Card` import so there's only one statement

## Testing
- `npm --prefix frontend/react-app run build`

------
https://chatgpt.com/codex/tasks/task_e_688184273d2c8324ac35cf380d769bfc