### PR TITLE
Add InsightsPanel test and fix metrics arrays

### DIFF
--- a/frontend/react-app/src/InsightsPanel.jsx
+++ b/frontend/react-app/src/InsightsPanel.jsx
@@ -28,9 +28,16 @@ export default function InsightsPanel({ weekly }) {
     intensity: d.steps / 100,
   }))
 
-  const restMA = movingAverage(data.map(d => d.resting_hr), 3)
-  const vo2MA = movingAverage(data.map(d => d.vo2max), 3)
-  const sleepMA = movingAverage(data.map(d => d.sleep_hours), 3)
+  const labels = data.map(d => d.date)
+  const sleep = data.map(d => d.sleep_hours)
+  const resting = data.map(d => d.resting_hr)
+  const vo2 = data.map(d => d.vo2max)
+  const steps = data.map(d => d.steps)
+  const intensity = data.map(d => d.intensity)
+
+  const restMA = movingAverage(resting, 3)
+  const vo2MA = movingAverage(vo2, 3)
+  const sleepMA = movingAverage(sleep, 3)
 
   data.forEach((d, i) => {
     d.resting_hr_ma = restMA[i]

--- a/frontend/react-app/src/InsightsPanel.test.jsx
+++ b/frontend/react-app/src/InsightsPanel.test.jsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi as viFn } from 'vitest'
+
+viFn.mock('recharts', () => ({
+  AreaChart: ({ children }) => <svg data-testid="area-chart">{children}</svg>,
+  Area: () => <g />,
+  LineChart: ({ children }) => <svg data-testid="line-chart">{children}</svg>,
+  Line: () => <g />,
+  XAxis: () => <g />,
+  YAxis: () => <g />,
+  Tooltip: () => <div>Tooltip</div>,
+  ResponsiveContainer: ({ children }) => <div>{children}</div>,
+}))
+
+describe('InsightsPanel', () => {
+  it('renders charts for weekly data', async () => {
+    const { default: InsightsPanel } = await import('./InsightsPanel')
+    const weekly = [
+      { time: '2024-01-01', steps: 100, resting_hr: 60, vo2max: 50, sleep_hours: 8 },
+      { time: '2024-01-02', steps: 200, resting_hr: 62, vo2max: 51, sleep_hours: 7 },
+      { time: '2024-01-03', steps: 150, resting_hr: 64, vo2max: 52, sleep_hours: 6 },
+    ]
+    render(<InsightsPanel weekly={weekly} />)
+    expect(screen.getByText(/Steps vs intensity/)).toBeInTheDocument()
+    expect(screen.getAllByTestId('area-chart').length).toBe(1)
+    expect(screen.getAllByTestId('line-chart').length).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary
- fix `InsightsPanel` to compute chart data arrays correctly
- add Vitest for `InsightsPanel` with Recharts mocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68818642c5fc83248a37c5b554b5c718