### PR TITLE
Fix transparent favicon

### DIFF
--- a/frontend/react-app/public/favicon.svg
+++ b/frontend/react-app/public/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <rect width="100" height="100" fill="white"/>
+  <rect width="100" height="100" fill="none"/>
   <text x="50" y="55" font-size="55" text-anchor="middle" fill="black" font-family="Arial, Helvetica, sans-serif" dominant-baseline="middle">AJO</text>
 </svg>


### PR DESCRIPTION
## Summary
- make favicon background transparent by setting fill to none

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68818e5e374c8324a98843d4eeb66a6a