### PR TITLE
Add Garmin backfill script

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ npm test   # runs "npm test --prefix api" and "npm test --prefix frontend/react-
 - `GARMIN_EMAIL` and `GARMIN_PASSWORD` for `save-garmin-session.js`
 - `GARMIN_COOKIE_PATH` location of the saved session
 
+### Backfill historical data
+
+Use `scripts/backfill-garmin-history.js` to populate InfluxDB with data from
+past dates. Provide a start and end date or a number of days to backfill.
+
+```bash
+# backfill between two dates (inclusive)
+node scripts/backfill-garmin-history.js 2024-01-01 2024-01-07
+
+# or backfill the last 30 days
+node scripts/backfill-garmin-history.js --days 30
+```
+
 ## License
 
 [MIT](LICENSE)

--- a/api/scraper.js
+++ b/api/scraper.js
@@ -30,15 +30,33 @@ async function login() {
 }
 
 async function writeToInflux(summary) {
-  if (!process.env.INFLUX_URL || !process.env.INFLUX_TOKEN || !process.env.INFLUX_ORG || !process.env.INFLUX_BUCKET) return;
+  if (
+    !process.env.INFLUX_URL ||
+    !process.env.INFLUX_TOKEN ||
+    !process.env.INFLUX_ORG ||
+    !process.env.INFLUX_BUCKET
+  ) {
+    return;
+  }
 
-  const influx = new InfluxDB({ url: process.env.INFLUX_URL, token: process.env.INFLUX_TOKEN });
-  const writeApi = influx.getWriteApi(process.env.INFLUX_ORG, process.env.INFLUX_BUCKET);
+  const influx = new InfluxDB({
+    url: process.env.INFLUX_URL,
+    token: process.env.INFLUX_TOKEN,
+  });
+  const writeApi = influx.getWriteApi(
+    process.env.INFLUX_ORG,
+    process.env.INFLUX_BUCKET
+  );
   const point = new Point('garmin_summary')
     .floatField('steps', summary.steps)
     .floatField('resting_hr', summary.resting_hr)
     .floatField('vo2max', summary.vo2max || 0)
     .floatField('sleep_hours', summary.sleep_hours);
+
+  if (summary.time) {
+    point.timestamp(new Date(summary.time));
+  }
+
   writeApi.writePoint(point);
   await writeApi.close();
 }
@@ -121,5 +139,8 @@ module.exports = {
   fetchHistory,
   fetchActivityRoute,
   fetchRecentActivities,
+  login,
+  writeToInflux,
+  gcClient,
 };
 

--- a/scripts/backfill-garmin-history.js
+++ b/scripts/backfill-garmin-history.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+const { login, writeToInflux, gcClient } = require('../api/scraper');
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error('Usage: node scripts/backfill-garmin-history.js <start> <end>');
+  console.error('   or: node scripts/backfill-garmin-history.js --days <n>');
+  process.exit(1);
+}
+
+let start;
+let end;
+
+if (args.includes('--days')) {
+  const idx = args.indexOf('--days');
+  const days = parseInt(args[idx + 1], 10);
+  if (isNaN(days) || days <= 0) usage();
+  end = new Date();
+  end.setHours(0, 0, 0, 0);
+  start = new Date(end);
+  start.setDate(start.getDate() - days + 1);
+} else if (args.length >= 2) {
+  start = new Date(args[0]);
+  end = new Date(args[1]);
+  if (isNaN(start) || isNaN(end)) usage();
+  start.setHours(0, 0, 0, 0);
+  end.setHours(0, 0, 0, 0);
+  if (start > end) usage();
+} else {
+  usage();
+}
+
+(async () => {
+  try {
+    await login();
+  } catch (err) {
+    console.error('Login failed:', err.message);
+    process.exit(1);
+  }
+
+  for (
+    let d = new Date(start);
+    d <= end;
+    d.setDate(d.getDate() + 1)
+  ) {
+    const dateStr = d.toISOString().slice(0, 10);
+    console.log(`Backfilling ${dateStr}...`);
+    try {
+      const steps = await gcClient.getSteps(d);
+      const hr = await gcClient.getHeartRate(d);
+      const sleep = await gcClient.getSleepData(d);
+      const summary = {
+        steps,
+        resting_hr: hr.restingHeartRate,
+        vo2max: hr.vo2max || 0,
+        sleep_hours: (sleep.dailySleepDTO.sleepTimeSeconds || 0) / 3600,
+        time: d.toISOString(),
+      };
+      await writeToInflux(summary);
+      console.log(`Stored data for ${dateStr}`);
+    } catch (err) {
+      console.error(`Failed to backfill ${dateStr}:`, err.message);
+    }
+  }
+})();


### PR DESCRIPTION
## Summary
- expose helper utilities in `scraper.js`
- allow timestamp in `writeToInflux`
- script to backfill Garmin history
- document the new script in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881988039908324a4f52faaead017d9