### PR TITLE
Add activities page

### DIFF
--- a/frontend/react-app/src/ActivitiesPage.test.jsx
+++ b/frontend/react-app/src/ActivitiesPage.test.jsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { vi as viFn, describe, it, expect } from 'vitest'
+
+viFn.mock('react-leaflet', () => ({
+  MapContainer: ({ children }) => <div>{children}</div>,
+  TileLayer: () => <div>Tile</div>,
+  Polyline: () => <div>Line</div>,
+}))
+
+viFn.mock('./RouteMap.jsx', () => ({ default: () => <div>Map</div> }))
+
+describe('ActivitiesPage', () => {
+  it('loads activities and route', async () => {
+    const { default: ActivitiesPage } = await import('./pages/ActivitiesPage')
+    global.fetch = viFn.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([{ id: '1', name: 'Run' }]),
+        text: () => Promise.resolve(''),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([{ lat: 1, lon: 2 }]),
+        text: () => Promise.resolve(''),
+      })
+    render(<ActivitiesPage />)
+    await screen.findByText('Run')
+    await screen.findByText('Map')
+  })
+})

--- a/frontend/react-app/src/App.jsx
+++ b/frontend/react-app/src/App.jsx
@@ -1,11 +1,13 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import DashboardPage from '@/pages/DashboardPage'
+import ActivitiesPage from '@/pages/ActivitiesPage'
 
 export default function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/activities" element={<ActivitiesPage />} />
         <Route path="*" element={<Navigate to="/dashboard" replace />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/react-app/src/pages/ActivitiesPage.tsx
+++ b/frontend/react-app/src/pages/ActivitiesPage.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react'
+import RouteMap from '@/RouteMap'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+} from '@/components/ui/card'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+
+export default function ActivitiesPage() {
+  const [activities, setActivities] = useState<any[]>([])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [route, setRoute] = useState<any[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function loadActivities() {
+    try {
+      const res = await fetch('/api/activities')
+      if (!res.ok) throw new Error(await res.text())
+      const data = await res.json()
+      setActivities(data)
+      setSelectedId(data[0]?.id ?? null)
+      setError(null)
+    } catch (err: any) {
+      console.error(err)
+      setError(err.message)
+    }
+  }
+
+  async function loadRoute(id: string) {
+    try {
+      const res = await fetch(`/api/activity/${id}`)
+      if (!res.ok) throw new Error(await res.text())
+      setRoute(await res.json())
+      setError(null)
+    } catch (err: any) {
+      console.error(err)
+      setError(err.message)
+    }
+  }
+
+  useEffect(() => {
+    loadActivities()
+  }, [])
+
+  useEffect(() => {
+    if (selectedId) {
+      loadRoute(selectedId)
+    }
+  }, [selectedId])
+
+  return (
+    <main className="p-6 md:p-10 max-w-screen-xl mx-auto space-y-6">
+      <h1 className="text-2xl font-semibold">Recent Activities</h1>
+      {error && <p role="alert">Error: {error}</p>}
+      <Card>
+        <CardHeader className="flex items-center justify-between">
+          <CardTitle>Activity Routes</CardTitle>
+          <Button size="sm" onClick={loadActivities}>Reload</Button>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Select value={selectedId ?? ''} onValueChange={setSelectedId}>
+            <SelectTrigger className="w-full max-w-xs">
+              <SelectValue placeholder="Choose an activity" />
+            </SelectTrigger>
+            <SelectContent>
+              {activities.map(a => (
+                <SelectItem key={a.id} value={a.id}>
+                  {a.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {route && <RouteMap points={route} />}
+        </CardContent>
+      </Card>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- create an ActivitiesPage that fetches recent activities and shows route maps
- add route for the new page in `App.jsx`
- test ActivitiesPage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881a7ddc25c8324a98dfc4f3487a7c7