### PR TITLE
Expand backfill instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,5 @@ INFLUX_TOKEN=your-token
 INFLUX_ORG=your-org
 INFLUX_BUCKET=garmin
 PORT=3002
+# Absolute path to the saved Garmin session used for authentication
 GARMIN_COOKIE_PATH=/path/to/saved/session.json

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ Run all API and React tests with:
 npm test   # runs "npm test --prefix api" and "npm test --prefix frontend"
 ```
 
+### Running scripts
+
+Node scripts expect environment variables from `.env`. You can load them using
+`dotenv-cli`:
+
+```bash
+npx dotenv -e .env -- node scripts/backfill-garmin-history.js --days 30
+```
+
 ### Required environment variables
 
 - `GARMIN_EMAIL` and `GARMIN_PASSWORD` for `save-garmin-session.js`
@@ -74,6 +83,10 @@ node scripts/backfill-garmin-history.js 2024-01-01 2024-01-07
 # or backfill the last 30 days
 node scripts/backfill-garmin-history.js --days 30
 ```
+
+This script requires the same environment configuration as the main API.
+Ensure your `.env` file contains valid `INFLUX_URL`, `INFLUX_TOKEN`,
+`INFLUX_ORG`, `INFLUX_BUCKET` and `GARMIN_COOKIE_PATH` values before running it.
 
 ## License
 

--- a/scripts/backfill-garmin-history.js
+++ b/scripts/backfill-garmin-history.js
@@ -1,5 +1,20 @@
 #!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
 const { login, writeToInflux, gcClient } = require('../api/scraper');
+
+if (!process.env.GARMIN_COOKIE_PATH) {
+  const sessionPath = path.resolve(__dirname, '../.session');
+  if (fs.existsSync(sessionPath)) {
+    process.env.GARMIN_COOKIE_PATH = sessionPath;
+  }
+}
+
+if (!process.env.GARMIN_COOKIE_PATH) {
+  console.error('GARMIN_COOKIE_PATH not set and no .session file found');
+  process.exit(1);
+}
 
 const args = process.argv.slice(2);
 


### PR DESCRIPTION
## Summary
- clarify environment variables needed for backfill script in README
- mention using `npx dotenv` to load `.env` when running scripts
- note how `GARMIN_COOKIE_PATH` is used in `.env.example`
- auto-detect `.session` file in the backfill script

## Testing
- `npm install`
- `npm install --prefix api`
- `npm install --prefix frontend`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688221a25954832486683003f0c2c596