### PR TITLE
Add dashboard components

### DIFF
--- a/frontend-next/src/components/Dashboard/ActivitiesTable.tsx
+++ b/frontend-next/src/components/Dashboard/ActivitiesTable.tsx
@@ -1,0 +1,42 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import useMockData from "@/hooks/useMockData"
+
+export default function ActivitiesTable() {
+  const { data, isLoading } = useMockData()
+
+  if (isLoading || !data) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Weekly Activities</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b">
+              <tr className="text-muted-foreground">
+                <th className="py-2 pr-4">Date</th>
+                <th className="py-2 pr-4">Steps</th>
+                <th className="py-2 pr-4">Resting HR</th>
+                <th className="py-2">Sleep</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.weekly.map(entry => (
+                <tr key={entry.time} className="border-b last:border-b-0">
+                  <td className="py-2 pr-4">
+                    {new Date(entry.time).toLocaleDateString()}
+                  </td>
+                  <td className="py-2 pr-4">{entry.steps}</td>
+                  <td className="py-2 pr-4">{entry.resting_hr}</td>
+                  <td className="py-2">{entry.sleep_hours} hrs</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend-next/src/components/Dashboard/GoalsRing.tsx
+++ b/frontend-next/src/components/Dashboard/GoalsRing.tsx
@@ -1,0 +1,54 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import useMockData from "@/hooks/useMockData"
+
+export default function GoalsRing({ goal = 10000 }: { goal?: number }) {
+  const { data, isLoading } = useMockData()
+
+  if (isLoading || !data) return null
+
+  const steps = data.summary.steps
+  const pct = Math.min((steps / goal) * 100, 100)
+  const radius = 52
+  const circ = 2 * Math.PI * radius
+  const offset = circ - (pct / 100) * circ
+
+  return (
+    <Card className="flex items-center justify-center">
+      <CardHeader>
+        <CardTitle>Daily Goal</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <svg width="120" height="120" className="block mx-auto">
+          <circle
+            cx="60"
+            cy="60"
+            r={radius}
+            stroke="hsl(var(--muted))"
+            strokeWidth="8"
+            fill="none"
+          />
+          <circle
+            cx="60"
+            cy="60"
+            r={radius}
+            stroke="hsl(var(--primary))"
+            strokeWidth="8"
+            fill="none"
+            strokeDasharray={circ}
+            strokeDashoffset={offset}
+            strokeLinecap="round"
+          />
+          <text
+            x="50%"
+            y="50%"
+            dominantBaseline="middle"
+            textAnchor="middle"
+            className="text-xl font-semibold"
+          >
+            {Math.round(pct)}%
+          </text>
+        </svg>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend-next/src/components/Dashboard/InsightsChart.tsx
+++ b/frontend-next/src/components/Dashboard/InsightsChart.tsx
@@ -1,0 +1,44 @@
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import useMockData from "@/hooks/useMockData"
+
+export default function InsightsChart() {
+  const { data, isLoading } = useMockData()
+
+  if (isLoading || !data) return null
+
+  const chartData = data.weekly.map(d => ({
+    name: new Date(d.time).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    }),
+    steps: d.steps,
+  }))
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Insights</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="w-full h-48">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartData} margin={{ top: 10, right: 20, bottom: 0, left: 0 }}>
+              <XAxis dataKey="name" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="steps" stroke="hsl(var(--primary))" strokeWidth={2} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend-next/src/components/Dashboard/MapView.tsx
+++ b/frontend-next/src/components/Dashboard/MapView.tsx
@@ -1,0 +1,27 @@
+import Image from "next/image"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import useMockData from "@/hooks/useMockData"
+
+export default function MapView() {
+  const { data, isLoading } = useMockData()
+
+  if (isLoading || !data) return null
+
+  const latest = data.weekly[0]
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Map View</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col items-center gap-2">
+        <Image src="/globe.svg" alt="Map" width={120} height={120} />
+        {latest && (
+          <p className="text-sm text-muted-foreground">
+            Showing data for {new Date(latest.time).toLocaleDateString()}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend-next/src/components/Dashboard/OverviewCard.tsx
+++ b/frontend-next/src/components/Dashboard/OverviewCard.tsx
@@ -1,0 +1,34 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import useMockData from "@/hooks/useMockData"
+
+export default function OverviewCard() {
+  const { data, isLoading } = useMockData()
+
+  if (isLoading || !data) return null
+
+  const { summary } = data
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Daily Overview</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-1 text-sm">
+          <li>
+            <span className="font-semibold">Steps:</span> {summary.steps}
+          </li>
+          <li>
+            <span className="font-semibold">Resting HR:</span> {summary.resting_hr}
+          </li>
+          <li>
+            <span className="font-semibold">VO₂ Max:</span> {summary.vo2max}
+          </li>
+          <li>
+            <span className="font-semibold">Sleep:</span> {summary.sleep_hours} hrs
+          </li>
+        </ul>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary
- add `OverviewCard`, `ActivitiesTable`, `InsightsChart`, `GoalsRing`, and `MapView` components under `src/components/Dashboard`
- each component fetches data using `useMockData` and displays mock values using shadcn/ui primitives

## Testing
- `npm ci`
- `npm ci --prefix api`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68825eef1d448324b5c19b3d9bf4b1c6