### PR TITLE
Revise mock data schema

### DIFF
--- a/frontend-next/public/mockData.json
+++ b/frontend-next/public/mockData.json
@@ -1,11 +1,11 @@
 {
-  "summary": {
+  "metrics": {
     "steps": 12345,
     "resting_hr": 60,
     "vo2max": 50,
     "sleep_hours": 7.5
   },
-  "weekly": [
+  "activities": [
     { "time": "2024-05-01T00:00:00Z", "steps": 10000, "resting_hr": 60, "vo2max": 50, "sleep_hours": 7.0 },
     { "time": "2024-05-02T00:00:00Z", "steps": 11000, "resting_hr": 61, "vo2max": 50, "sleep_hours": 7.2 },
     { "time": "2024-05-03T00:00:00Z", "steps": 9000, "resting_hr": 59, "vo2max": 49, "sleep_hours": 6.8 },
@@ -14,6 +14,10 @@
     { "time": "2024-05-06T00:00:00Z", "steps": 13000, "resting_hr": 57, "vo2max": 50, "sleep_hours": 7.8 },
     { "time": "2024-05-07T00:00:00Z", "steps": 10000, "resting_hr": 59, "vo2max": 50, "sleep_hours": 7.6 }
   ],
+  "goals": {
+    "steps": 10000,
+    "sleep_hours": 8
+  },
   "gps": {
     "coordinates": [
       [37.7749, -122.4194],

--- a/frontend-next/src/components/Dashboard/ActivitiesTable.tsx
+++ b/frontend-next/src/components/Dashboard/ActivitiesTable.tsx
@@ -23,7 +23,7 @@ export default function ActivitiesTable() {
               </tr>
             </thead>
             <tbody>
-              {data.weekly.map(entry => (
+              {data.activities.map(entry => (
                 <tr key={entry.time} className="border-b last:border-b-0">
                   <td className="py-2 pr-4">
                     {new Date(entry.time).toLocaleDateString()}

--- a/frontend-next/src/components/Dashboard/GoalsRing.tsx
+++ b/frontend-next/src/components/Dashboard/GoalsRing.tsx
@@ -1,13 +1,14 @@
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import useMockData from "@/hooks/useMockData"
 
-export default function GoalsRing({ goal = 10000 }: { goal?: number }) {
+export default function GoalsRing({ goal }: { goal?: number }) {
   const { data, isLoading } = useMockData()
 
   if (isLoading || !data) return null
 
-  const steps = data.summary.steps
-  const pct = Math.min((steps / goal) * 100, 100)
+  const steps = data.metrics.steps
+  const stepGoal = goal ?? data.goals.steps
+  const pct = Math.min((steps / stepGoal) * 100, 100)
   const radius = 52
   const circ = 2 * Math.PI * radius
   const offset = circ - (pct / 100) * circ

--- a/frontend-next/src/components/Dashboard/InsightsChart.tsx
+++ b/frontend-next/src/components/Dashboard/InsightsChart.tsx
@@ -14,7 +14,7 @@ export default function InsightsChart() {
 
   if (isLoading || !data) return null
 
-  const chartData = data.weekly.map(d => ({
+  const chartData = data.activities.map(d => ({
     name: new Date(d.time).toLocaleDateString(undefined, {
       month: "short",
       day: "numeric",

--- a/frontend-next/src/components/Dashboard/OverviewCard.tsx
+++ b/frontend-next/src/components/Dashboard/OverviewCard.tsx
@@ -6,7 +6,7 @@ export default function OverviewCard() {
 
   if (isLoading || !data) return null
 
-  const { summary } = data
+  const { metrics } = data
 
   return (
     <Card>
@@ -16,16 +16,16 @@ export default function OverviewCard() {
       <CardContent>
         <ul className="space-y-1 text-sm">
           <li>
-            <span className="font-semibold">Steps:</span> {summary.steps}
+            <span className="font-semibold">Steps:</span> {metrics.steps}
           </li>
           <li>
-            <span className="font-semibold">Resting HR:</span> {summary.resting_hr}
+            <span className="font-semibold">Resting HR:</span> {metrics.resting_hr}
           </li>
           <li>
-            <span className="font-semibold">VO₂ Max:</span> {summary.vo2max}
+            <span className="font-semibold">VO₂ Max:</span> {metrics.vo2max}
           </li>
           <li>
-            <span className="font-semibold">Sleep:</span> {summary.sleep_hours} hrs
+            <span className="font-semibold">Sleep:</span> {metrics.sleep_hours} hrs
           </li>
         </ul>
       </CardContent>

--- a/frontend-next/src/components/Dashboard/__tests__/OverviewCard.test.tsx
+++ b/frontend-next/src/components/Dashboard/__tests__/OverviewCard.test.tsx
@@ -15,6 +15,6 @@ afterEach(() => {
 
 test('renders the step count from mockData', async () => {
   render(<OverviewCard />)
-  const stepItem = await screen.findByText(String(mockData.summary.steps))
+  const stepItem = await screen.findByText(String(mockData.metrics.steps))
   expect(stepItem).toBeInTheDocument()
 })

--- a/frontend-next/src/data/mockData.json
+++ b/frontend-next/src/data/mockData.json
@@ -1,11 +1,11 @@
 {
-  "summary": {
+  "metrics": {
     "steps": 12345,
     "resting_hr": 60,
     "vo2max": 50,
     "sleep_hours": 7.5
   },
-  "weekly": [
+  "activities": [
     { "time": "2024-05-01T00:00:00Z", "steps": 10000, "resting_hr": 60, "vo2max": 50, "sleep_hours": 7.0 },
     { "time": "2024-05-02T00:00:00Z", "steps": 11000, "resting_hr": 61, "vo2max": 50, "sleep_hours": 7.2 },
     { "time": "2024-05-03T00:00:00Z", "steps": 9000, "resting_hr": 59, "vo2max": 49, "sleep_hours": 6.8 },
@@ -14,6 +14,10 @@
     { "time": "2024-05-06T00:00:00Z", "steps": 13000, "resting_hr": 57, "vo2max": 50, "sleep_hours": 7.8 },
     { "time": "2024-05-07T00:00:00Z", "steps": 10000, "resting_hr": 59, "vo2max": 50, "sleep_hours": 7.6 }
   ],
+  "goals": {
+    "steps": 10000,
+    "sleep_hours": 8
+  },
   "gps": {
     "coordinates": [
       [37.7749, -122.4194],


### PR DESCRIPTION
## Summary
- switch mock data to use `metrics`, `activities`, `goals` and `gps`
- update dashboard components to read the new fields
- adjust test for changed schema

## Testing
- `npm test` *(fails: Cannot find module 'next/jest')*

------
https://chatgpt.com/codex/tasks/task_e_68829c2340bc8324a600666d71923d2e