### PR TITLE
Add spinner for loading state

### DIFF
--- a/frontend-next/src/components/Dashboard/ActivitiesTable.tsx
+++ b/frontend-next/src/components/Dashboard/ActivitiesTable.tsx
@@ -1,10 +1,12 @@
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import Spinner from "@/components/Spinner"
 import useMockData from "@/hooks/useMockData"
 
 export default function ActivitiesTable() {
   const { data, isLoading } = useMockData()
 
-  if (isLoading || !data) return null
+  if (isLoading) return <Spinner />
+  if (!data) return null
 
   return (
     <Card>

--- a/frontend-next/src/components/Dashboard/GoalsRing.tsx
+++ b/frontend-next/src/components/Dashboard/GoalsRing.tsx
@@ -1,10 +1,12 @@
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import Spinner from "@/components/Spinner"
 import useMockData from "@/hooks/useMockData"
 
 export default function GoalsRing({ goal }: { goal?: number }) {
   const { data, isLoading } = useMockData()
 
-  if (isLoading || !data) return null
+  if (isLoading) return <Spinner />
+  if (!data) return null
 
   const steps = data.metrics.steps
   const stepGoal = goal ?? data.goals.steps

--- a/frontend-next/src/components/Dashboard/InsightsChart.tsx
+++ b/frontend-next/src/components/Dashboard/InsightsChart.tsx
@@ -7,12 +7,14 @@ import {
   ResponsiveContainer,
 } from "recharts"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import Spinner from "@/components/Spinner"
 import useMockData from "@/hooks/useMockData"
 
 export default function InsightsChart() {
   const { data, isLoading } = useMockData()
 
-  if (isLoading || !data) return null
+  if (isLoading) return <Spinner />
+  if (!data) return null
 
   const chartData = data.activities.map(d => ({
     name: new Date(d.time).toLocaleDateString(undefined, {

--- a/frontend-next/src/components/Dashboard/MapView.tsx
+++ b/frontend-next/src/components/Dashboard/MapView.tsx
@@ -5,6 +5,7 @@ import "leaflet.heat"
 import { MapContainer, TileLayer, Polyline, useMap } from "react-leaflet"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
+import Spinner from "@/components/Spinner"
 import useMockData from "@/hooks/useMockData"
 
 interface HeatProps {
@@ -28,7 +29,8 @@ export default function MapView() {
   const { data, isLoading } = useMockData()
   const [heat, setHeat] = useState(false)
 
-  if (isLoading || !data) return null
+  if (isLoading) return <Spinner />
+  if (!data) return null
 
   const coords = data.gps?.coordinates || []
   if (!coords.length) return null

--- a/frontend-next/src/components/Dashboard/OverviewCard.tsx
+++ b/frontend-next/src/components/Dashboard/OverviewCard.tsx
@@ -1,10 +1,12 @@
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import Spinner from "@/components/Spinner"
 import useMockData from "@/hooks/useMockData"
 
 export default function OverviewCard() {
   const { data, isLoading } = useMockData()
 
-  if (isLoading || !data) return null
+  if (isLoading) return <Spinner />
+  if (!data) return null
 
   const { metrics } = data
 

--- a/frontend-next/src/components/Spinner.tsx
+++ b/frontend-next/src/components/Spinner.tsx
@@ -1,0 +1,10 @@
+import { LoaderCircle } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export default function Spinner({ className }: { className?: string }) {
+  return (
+    <LoaderCircle
+      className={cn('size-5 animate-spin text-muted-foreground', className)}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- create a Spinner component
- show Spinner while mock data loads in dashboard components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882b0dcce008324b9f1c64a54ccbb53