### PR TITLE
Add Garmin data hook with env-based selection

### DIFF
--- a/frontend-next/src/components/Dashboard/ActivitiesTable.tsx
+++ b/frontend-next/src/components/Dashboard/ActivitiesTable.tsx
@@ -1,9 +1,12 @@
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import Spinner from "@/components/Spinner"
 import useMockData from "@/hooks/useMockData"
+import useGarminData from "@/hooks/useGarminData"
 
 export default function ActivitiesTable() {
-  const { data, isLoading } = useMockData()
+  const useData =
+    process.env.NEXT_PUBLIC_MOCK_MODE === 'false' ? useGarminData : useMockData
+  const { data, isLoading } = useData()
 
   if (isLoading) return <Spinner />
   if (!data) return null

--- a/frontend-next/src/components/Dashboard/GoalsRing.tsx
+++ b/frontend-next/src/components/Dashboard/GoalsRing.tsx
@@ -1,9 +1,12 @@
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import Spinner from "@/components/Spinner"
 import useMockData from "@/hooks/useMockData"
+import useGarminData from "@/hooks/useGarminData"
 
 export default function GoalsRing({ goal }: { goal?: number }) {
-  const { data, isLoading } = useMockData()
+  const useData =
+    process.env.NEXT_PUBLIC_MOCK_MODE === 'false' ? useGarminData : useMockData
+  const { data, isLoading } = useData()
 
   if (isLoading) return <Spinner />
   if (!data) return null

--- a/frontend-next/src/components/Dashboard/InsightsChart.tsx
+++ b/frontend-next/src/components/Dashboard/InsightsChart.tsx
@@ -9,9 +9,12 @@ import {
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import Spinner from "@/components/Spinner"
 import useMockData from "@/hooks/useMockData"
+import useGarminData from "@/hooks/useGarminData"
 
 export default function InsightsChart() {
-  const { data, isLoading } = useMockData()
+  const useData =
+    process.env.NEXT_PUBLIC_MOCK_MODE === 'false' ? useGarminData : useMockData
+  const { data, isLoading } = useData()
 
   if (isLoading) return <Spinner />
   if (!data) return null

--- a/frontend-next/src/components/Dashboard/MapView.tsx
+++ b/frontend-next/src/components/Dashboard/MapView.tsx
@@ -7,6 +7,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import Spinner from "@/components/Spinner"
 import useMockData from "@/hooks/useMockData"
+import useGarminData from "@/hooks/useGarminData"
 
 interface HeatProps {
   points: [number, number][]
@@ -26,7 +27,9 @@ function HeatLayer({ points }: HeatProps) {
 }
 
 export default function MapView() {
-  const { data, isLoading } = useMockData()
+  const useData =
+    process.env.NEXT_PUBLIC_MOCK_MODE === 'false' ? useGarminData : useMockData
+  const { data, isLoading } = useData()
   const [heat, setHeat] = useState(false)
 
   if (isLoading) return <Spinner />

--- a/frontend-next/src/components/Dashboard/OverviewCard.tsx
+++ b/frontend-next/src/components/Dashboard/OverviewCard.tsx
@@ -1,9 +1,12 @@
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import Spinner from "@/components/Spinner"
 import useMockData from "@/hooks/useMockData"
+import useGarminData from "@/hooks/useGarminData"
 
 export default function OverviewCard() {
-  const { data, isLoading } = useMockData()
+  const useData =
+    process.env.NEXT_PUBLIC_MOCK_MODE === 'false' ? useGarminData : useMockData
+  const { data, isLoading } = useData()
 
   if (isLoading) return <Spinner />
   if (!data) return null

--- a/frontend-next/src/hooks/useGarminData.ts
+++ b/frontend-next/src/hooks/useGarminData.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+import type { MockData } from './useMockData'
+
+export default function useGarminData() {
+  const [data, setData] = useState<MockData | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [summaryRes, weeklyRes, actsRes] = await Promise.all([
+          fetch('/api/summary'),
+          fetch('/api/weekly'),
+          fetch('/api/activities?limit=1'),
+        ])
+
+        if (!summaryRes.ok) throw new Error(await summaryRes.text())
+        if (!weeklyRes.ok) throw new Error(await weeklyRes.text())
+        if (!actsRes.ok) throw new Error(await actsRes.text())
+
+        const summary = await summaryRes.json()
+        const weekly = await weeklyRes.json()
+        const acts = await actsRes.json()
+
+        let gps
+        if (Array.isArray(acts) && acts.length) {
+          const routeRes = await fetch(`/api/activity/${acts[0].id}`)
+          if (routeRes.ok) {
+            const points: { lat: number; lon: number }[] = await routeRes.json()
+            gps = {
+              coordinates: points.map(p => [p.lat, p.lon] as [number, number]),
+            }
+          }
+        }
+
+        setData({
+          metrics: summary,
+          activities: weekly,
+          goals: { steps: 10000, sleep_hours: 8 },
+          gps,
+        })
+        setError(null)
+      } catch (err) {
+        setError((err as Error).message)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    load()
+  }, [])
+
+  return { data, isLoading, error }
+}


### PR DESCRIPTION
## Summary
- add a new `useGarminData` hook to load data from the API
- pick `useGarminData` or `useMockData` at runtime based on `NEXT_PUBLIC_MOCK_MODE`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882b34d1b3083249d2c6b7bf86141a8