### PR TITLE
Add history data fields and update dashboard

### DIFF
--- a/frontend-next/public/mockData.json
+++ b/frontend-next/public/mockData.json
@@ -5,6 +5,10 @@
     "vo2max": 50,
     "sleep_hours": 7.5
   },
+  "stepsHistory": [10000, 11000, 9000, 12000, 8000, 13000, 10000],
+  "hrZones": [20, 40, 30, 10],
+  "sleepStages": [3, 4, 2, 1],
+  "vo2History": [49, 50, 50, 50, 51, 50, 50],
   "activities": [
     { "time": "2024-05-01T00:00:00Z", "steps": 10000, "resting_hr": 60, "vo2max": 50, "sleep_hours": 7.0 },
     { "time": "2024-05-02T00:00:00Z", "steps": 11000, "resting_hr": 61, "vo2max": 50, "sleep_hours": 7.2 },

--- a/frontend-next/src/components/Dashboard/InsightsChart.tsx
+++ b/frontend-next/src/components/Dashboard/InsightsChart.tsx
@@ -19,12 +19,9 @@ export default function InsightsChart() {
   if (isLoading) return <Spinner />
   if (!data) return null
 
-  const chartData = data.activities.map(d => ({
-    name: new Date(d.time).toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-    }),
-    steps: d.steps,
+  const chartData = data.stepsHistory.map((steps, i) => ({
+    name: `Day ${i + 1}`,
+    steps,
   }))
 
   return (

--- a/frontend-next/src/components/Dashboard/OverviewCard.tsx
+++ b/frontend-next/src/components/Dashboard/OverviewCard.tsx
@@ -11,7 +11,7 @@ export default function OverviewCard() {
   if (isLoading) return <Spinner />
   if (!data) return null
 
-  const { metrics } = data
+  const { metrics, stepsHistory, hrZones, sleepStages, vo2History } = data
 
   return (
     <Card>
@@ -31,6 +31,18 @@ export default function OverviewCard() {
           </li>
           <li>
             <span className="font-semibold">Sleep:</span> {metrics.sleep_hours} hrs
+          </li>
+          <li>
+            <span className="font-semibold">Steps History:</span> {stepsHistory.join(', ')}
+          </li>
+          <li>
+            <span className="font-semibold">HR Zones:</span> {hrZones.join(', ')}
+          </li>
+          <li>
+            <span className="font-semibold">Sleep Stages:</span> {sleepStages.join(', ')}
+          </li>
+          <li>
+            <span className="font-semibold">VO₂ History:</span> {vo2History.join(', ')}
           </li>
         </ul>
       </CardContent>

--- a/frontend-next/src/data/mockData.json
+++ b/frontend-next/src/data/mockData.json
@@ -5,6 +5,10 @@
     "vo2max": 50,
     "sleep_hours": 7.5
   },
+  "stepsHistory": [10000, 11000, 9000, 12000, 8000, 13000, 10000],
+  "hrZones": [20, 40, 30, 10],
+  "sleepStages": [3, 4, 2, 1],
+  "vo2History": [49, 50, 50, 50, 51, 50, 50],
   "activities": [
     { "time": "2024-05-01T00:00:00Z", "steps": 10000, "resting_hr": 60, "vo2max": 50, "sleep_hours": 7.0 },
     { "time": "2024-05-02T00:00:00Z", "steps": 11000, "resting_hr": 61, "vo2max": 50, "sleep_hours": 7.2 },

--- a/frontend-next/src/hooks/useGarminData.ts
+++ b/frontend-next/src/hooks/useGarminData.ts
@@ -39,6 +39,10 @@ export default function useGarminData() {
           activities: weekly,
           goals: { steps: 10000, sleep_hours: 8 },
           gps,
+          stepsHistory: weekly.map(d => d.steps),
+          hrZones: [],
+          sleepStages: [],
+          vo2History: weekly.map(d => d.vo2max ?? 0),
         })
         setError(null)
       } catch (err) {


### PR DESCRIPTION
## Summary
- add history arrays to mock data
- display new metrics in OverviewCard
- chart stepsHistory in InsightsChart
- expose new fields from useGarminData

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882b76e38048324b5572eae4eb0029c