### PR TITLE
Add dashboard header and new tabs

### DIFF
--- a/frontend-next/src/components/Header.tsx
+++ b/frontend-next/src/components/Header.tsx
@@ -1,0 +1,18 @@
+import { Settings } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+export default function Header() {
+  return (
+    <header className="flex items-center justify-between gap-4">
+      <div className="flex items-center gap-3">
+        <span className="size-8 rounded-full bg-muted flex items-center justify-center text-sm font-medium text-muted-foreground">
+          A
+        </span>
+        <h1 className="text-xl font-semibold md:text-2xl">Garmin Dashboard</h1>
+      </div>
+      <Button variant="ghost" size="icon" aria-label="Settings">
+        <Settings className="size-5" />
+      </Button>
+    </header>
+  )
+}

--- a/frontend-next/src/pages/index.tsx
+++ b/frontend-next/src/pages/index.tsx
@@ -9,15 +9,19 @@ import GoalsRing from '@/components/Dashboard/GoalsRing'
 import MapView from '@/components/Dashboard/MapView'
 import InsightsChart from '@/components/Dashboard/InsightsChart'
 import ActivitiesTable from '@/components/Dashboard/ActivitiesTable'
+import Header from '@/components/Header'
 
 export default function HomePage() {
   return (
     <main className="p-6 md:p-10 max-w-screen-lg mx-auto space-y-6">
-      <h1 className="text-2xl font-semibold">Garmin Dashboard</h1>
+      <Header />
       <Tabs defaultValue="overview" className="space-y-6">
-        <TabsList>
+        <TabsList className="flex flex-wrap gap-2">
           <TabsTrigger value="overview">Overview</TabsTrigger>
           <TabsTrigger value="activities">Activities</TabsTrigger>
+          <TabsTrigger value="insights">Insights</TabsTrigger>
+          <TabsTrigger value="goals">Goals</TabsTrigger>
+          <TabsTrigger value="map">Map</TabsTrigger>
         </TabsList>
         <TabsContent value="overview" className="space-y-6">
           <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
@@ -37,6 +41,15 @@ export default function HomePage() {
         </TabsContent>
         <TabsContent value="activities">
           <ActivitiesTable />
+        </TabsContent>
+        <TabsContent value="insights">
+          <InsightsChart />
+        </TabsContent>
+        <TabsContent value="goals">
+          <GoalsRing />
+        </TabsContent>
+        <TabsContent value="map">
+          <MapView />
         </TabsContent>
       </Tabs>
     </main>


### PR DESCRIPTION
## Summary
- create a `Header` component with avatar, title and settings button
- display the new header on the dashboard
- add `Insights`, `Goals` and `Map` tabs so each widget has its own tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882b923a21c8324b2b72032aabc3a93