### PR TITLE
Add error alerts and placeholders

### DIFF
--- a/frontend-next/src/components/Dashboard/ActivitiesTable.tsx
+++ b/frontend-next/src/components/Dashboard/ActivitiesTable.tsx
@@ -1,14 +1,22 @@
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import Spinner from "@/components/Spinner"
+import { Alert, AlertDescription } from "@/components/ui/alert"
 import useMockData from "@/hooks/useMockData"
 import useGarminData from "@/hooks/useGarminData"
 
 export default function ActivitiesTable() {
   const useData =
     process.env.NEXT_PUBLIC_MOCK_MODE === 'false' ? useGarminData : useMockData
-  const { data, isLoading } = useData()
+  const { data, isLoading, error } = useData()
 
   if (isLoading) return <Spinner />
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>Failed to load dashboard data</AlertDescription>
+      </Alert>
+    )
+  }
   if (!data) return null
 
   return (
@@ -17,30 +25,34 @@ export default function ActivitiesTable() {
         <CardTitle>Weekly Activities</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="overflow-x-auto">
-          <table className="w-full text-left text-sm">
-            <thead className="border-b">
-              <tr className="text-muted-foreground">
-                <th className="py-2 pr-4">Date</th>
-                <th className="py-2 pr-4">Steps</th>
-                <th className="py-2 pr-4">Resting HR</th>
-                <th className="py-2">Sleep</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.activities.map(entry => (
-                <tr key={entry.time} className="border-b last:border-b-0">
-                  <td className="py-2 pr-4">
-                    {new Date(entry.time).toLocaleDateString()}
-                  </td>
-                  <td className="py-2 pr-4">{entry.steps}</td>
-                  <td className="py-2 pr-4">{entry.resting_hr}</td>
-                  <td className="py-2">{entry.sleep_hours} hrs</td>
+        {data.activities.length === 0 ? (
+          <>No activities yet</>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b">
+                <tr className="text-muted-foreground">
+                  <th className="py-2 pr-4">Date</th>
+                  <th className="py-2 pr-4">Steps</th>
+                  <th className="py-2 pr-4">Resting HR</th>
+                  <th className="py-2">Sleep</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {data.activities.map(entry => (
+                  <tr key={entry.time} className="border-b last:border-b-0">
+                    <td className="py-2 pr-4">
+                      {new Date(entry.time).toLocaleDateString()}
+                    </td>
+                    <td className="py-2 pr-4">{entry.steps}</td>
+                    <td className="py-2 pr-4">{entry.resting_hr}</td>
+                    <td className="py-2">{entry.sleep_hours} hrs</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </CardContent>
     </Card>
   )

--- a/frontend-next/src/components/Dashboard/GoalsRing.tsx
+++ b/frontend-next/src/components/Dashboard/GoalsRing.tsx
@@ -1,14 +1,22 @@
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import Spinner from "@/components/Spinner"
+import { Alert, AlertDescription } from "@/components/ui/alert"
 import useMockData from "@/hooks/useMockData"
 import useGarminData from "@/hooks/useGarminData"
 
 export default function GoalsRing({ goal }: { goal?: number }) {
   const useData =
     process.env.NEXT_PUBLIC_MOCK_MODE === 'false' ? useGarminData : useMockData
-  const { data, isLoading } = useData()
+  const { data, isLoading, error } = useData()
 
   if (isLoading) return <Spinner />
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>Failed to load dashboard data</AlertDescription>
+      </Alert>
+    )
+  }
   if (!data) return null
 
   const steps = data.metrics.steps

--- a/frontend-next/src/components/Dashboard/InsightsChart.tsx
+++ b/frontend-next/src/components/Dashboard/InsightsChart.tsx
@@ -8,16 +8,35 @@ import {
 } from "recharts"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import Spinner from "@/components/Spinner"
+import { Alert, AlertDescription } from "@/components/ui/alert"
 import useMockData from "@/hooks/useMockData"
 import useGarminData from "@/hooks/useGarminData"
 
 export default function InsightsChart() {
   const useData =
     process.env.NEXT_PUBLIC_MOCK_MODE === 'false' ? useGarminData : useMockData
-  const { data, isLoading } = useData()
+  const { data, isLoading, error } = useData()
 
   if (isLoading) return <Spinner />
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>Failed to load dashboard data</AlertDescription>
+      </Alert>
+    )
+  }
   if (!data) return null
+
+  if (data.stepsHistory.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Insights</CardTitle>
+        </CardHeader>
+        <CardContent>No activities yet</CardContent>
+      </Card>
+    )
+  }
 
   const chartData = data.stepsHistory.map((steps, i) => ({
     name: `Day ${i + 1}`,

--- a/frontend-next/src/components/Dashboard/MapView.tsx
+++ b/frontend-next/src/components/Dashboard/MapView.tsx
@@ -6,6 +6,7 @@ import { MapContainer, TileLayer, Polyline, useMap } from "react-leaflet"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import Spinner from "@/components/Spinner"
+import { Alert, AlertDescription } from "@/components/ui/alert"
 import useMockData from "@/hooks/useMockData"
 import useGarminData from "@/hooks/useGarminData"
 
@@ -29,14 +30,30 @@ function HeatLayer({ points }: HeatProps) {
 export default function MapView() {
   const useData =
     process.env.NEXT_PUBLIC_MOCK_MODE === 'false' ? useGarminData : useMockData
-  const { data, isLoading } = useData()
+  const { data, isLoading, error } = useData()
   const [heat, setHeat] = useState(false)
 
   if (isLoading) return <Spinner />
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>Failed to load dashboard data</AlertDescription>
+      </Alert>
+    )
+  }
   if (!data) return null
 
   const coords = data.gps?.coordinates || []
-  if (!coords.length) return null
+  if (!coords.length) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Map View</CardTitle>
+        </CardHeader>
+        <CardContent>No activities yet</CardContent>
+      </Card>
+    )
+  }
 
   const center: [number, number] = [coords[0][0], coords[0][1]]
 

--- a/frontend-next/src/components/Dashboard/OverviewCard.tsx
+++ b/frontend-next/src/components/Dashboard/OverviewCard.tsx
@@ -1,17 +1,41 @@
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import Spinner from "@/components/Spinner"
+import { Alert, AlertDescription } from "@/components/ui/alert"
 import useMockData from "@/hooks/useMockData"
 import useGarminData from "@/hooks/useGarminData"
 
 export default function OverviewCard() {
   const useData =
     process.env.NEXT_PUBLIC_MOCK_MODE === 'false' ? useGarminData : useMockData
-  const { data, isLoading } = useData()
+  const { data, isLoading, error } = useData()
 
   if (isLoading) return <Spinner />
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>Failed to load dashboard data</AlertDescription>
+      </Alert>
+    )
+  }
   if (!data) return null
 
   const { metrics, stepsHistory, hrZones, sleepStages, vo2History } = data
+
+  if (
+    stepsHistory.length === 0 &&
+    hrZones.length === 0 &&
+    sleepStages.length === 0 &&
+    vo2History.length === 0
+  ) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Daily Overview</CardTitle>
+        </CardHeader>
+        <CardContent>No data yet</CardContent>
+      </Card>
+    )
+  }
 
   return (
     <Card>

--- a/frontend-next/src/components/ui/alert.tsx
+++ b/frontend-next/src/components/ui/alert.tsx
@@ -1,0 +1,47 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-muted-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive: "text-destructive border-destructive/50 dark:border-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+interface AlertProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof alertVariants> {}
+
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+  ({ className, variant, ...props }, ref) => (
+    <div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
+  )
+)
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5 ref={ref} className={cn("mb-1 font-medium leading-none tracking-tight", className)} {...props} />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("text-sm [&_p]:leading-relaxed", className)} {...props} />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }


### PR DESCRIPTION
## Summary
- add `Alert` component
- show alert when hooks report an error
- display placeholders when no dashboard data is available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882ba87e4bc8324a31998b131b4ce9f