### PR TITLE
Fix SSR crash from MapView

### DIFF
--- a/frontend-next/src/pages/index.tsx
+++ b/frontend-next/src/pages/index.tsx
@@ -6,7 +6,11 @@ import {
 } from '@/components/ui/tabs'
 import OverviewCard from '@/components/Dashboard/OverviewCard'
 import GoalsRing from '@/components/Dashboard/GoalsRing'
-import MapView from '@/components/Dashboard/MapView'
+import dynamic from 'next/dynamic'
+
+const MapView = dynamic(() => import('@/components/Dashboard/MapView'), {
+  ssr: false,
+})
 import InsightsChart from '@/components/Dashboard/InsightsChart'
 import ActivitiesTable from '@/components/Dashboard/ActivitiesTable'
 import Header from '@/components/Header'


### PR DESCRIPTION
## Summary
- avoid loading leaflet during server-side rendering by loading MapView dynamically

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882cf8efc388324ae88b1065c7be6d2