### PR TITLE
Fix leaflet heat import

### DIFF
--- a/frontend-next/src/components/Dashboard/MapView.tsx
+++ b/frontend-next/src/components/Dashboard/MapView.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import 'leaflet/dist/leaflet.css'
-import { heatLayer } from 'leaflet.heat'
+import L from 'leaflet'
+import 'leaflet.heat'
 import { MapContainer, TileLayer, Polyline, useMap } from 'react-leaflet'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -17,7 +18,8 @@ function HeatLayer({ points }: HeatProps) {
   const map = useMap()
   useEffect(() => {
     if (!map) return
-    const layer = heatLayer(points, { radius: 25 })
+    // leaflet.heat adds heatLayer to the global L namespace
+    const layer = (L as any).heatLayer(points, { radius: 25 })
     layer.addTo(map)
     return () => {
       map.removeLayer(layer)

--- a/frontend-next/src/types/leaflet-heat.d.ts
+++ b/frontend-next/src/types/leaflet-heat.d.ts
@@ -1,6 +1,7 @@
-declare module 'leaflet.heat' {
-  import * as L from 'leaflet'
-  export function heatLayer(
+import * as L from 'leaflet'
+
+declare module 'leaflet' {
+  function heatLayer(
     latlngs: Array<[number, number]>,
     options?: unknown
   ): L.Layer


### PR DESCRIPTION
## Summary
- add side-effect import of `leaflet.heat`
- expose `heatLayer` on the Leaflet namespace for TypeScript

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882dce5e99c8324b5a177cd89cb8f78