### PR TITLE
Fix API routes with Next.js rewrite

### DIFF
--- a/frontend-next/next.config.ts
+++ b/frontend-next/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: "http://localhost:3002/api/:path*",
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- route `/api` requests from Next.js dev server to the Express API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882e7fa50a08324acae1bbe2b14b947