### PR TITLE
Improve dashboard with extended history features

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ node scripts/backfill-garmin-history.js 2024-01-01 2024-01-07
 node scripts/backfill-garmin-history.js --days 30
 ```
 
+For large backfills (e.g. 10 years of history) set `--days` to a big number:
+
+```bash
+node scripts/backfill-garmin-history.js --days 3650
+```
+
+### Viewing long-term history
+
+The dashboard's History tab queries `/api/history?days=N` using the number
+entered in the input field. Increase the days value to load more past data
+after running the backfill script.
+
 ## License
 
 [MIT](LICENSE)

--- a/frontend-next/src/components/Dashboard/HistoryTab.tsx
+++ b/frontend-next/src/components/Dashboard/HistoryTab.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react'
+import HistoryChart from '../HistoryChart'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import Spinner from '@/components/Spinner'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import useMockData from '@/hooks/useMockData'
+import useGarminData from '@/hooks/useGarminData'
+import { Input } from '@/components/ui/input'
+
+export default function HistoryTab() {
+  const [days, setDays] = useState(30)
+  const useData =
+    process.env.NEXT_PUBLIC_MOCK_MODE === 'false' ? useGarminData : useMockData
+  const { data, isLoading, error } = useData({ historyDays: days })
+
+  if (isLoading) return <Spinner />
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>Failed to load dashboard data</AlertDescription>
+      </Alert>
+    )
+  }
+  if (!data) return null
+
+  const chartData = data.activities.map(entry => ({
+    name: new Date(entry.time).toLocaleDateString(),
+    steps: entry.steps,
+  }))
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>History</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div>
+          <Input
+            type="number"
+            min={1}
+            value={days}
+            onChange={e => setDays(Number(e.target.value))}
+            className="w-24"
+          />
+        </div>
+        <HistoryChart data={chartData} goal={data.goals.steps} />
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend-next/src/components/Dashboard/MapView.tsx
+++ b/frontend-next/src/components/Dashboard/MapView.tsx
@@ -31,7 +31,7 @@ function HeatLayer({ points }: HeatProps) {
 export default function MapView() {
   const useData =
     process.env.NEXT_PUBLIC_MOCK_MODE === 'false' ? useGarminData : useMockData
-  const { data, isLoading, error } = useData()
+  const { data, isLoading, error } = useData({ activityLimit: 5 })
   const [heat, setHeat] = useState(false)
 
   if (isLoading) return <Spinner />

--- a/frontend-next/src/components/HistoryChart.tsx
+++ b/frontend-next/src/components/HistoryChart.tsx
@@ -4,7 +4,8 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-  ResponsiveContainer
+  ResponsiveContainer,
+  ReferenceLine,
 } from 'recharts'
 
 interface ChartData {
@@ -12,7 +13,12 @@ interface ChartData {
   steps: number
 }
 
-export default function HistoryChart({ data }: { data: ChartData[] }) {
+interface Props {
+  data: ChartData[]
+  goal?: number
+}
+
+export default function HistoryChart({ data, goal }: Props) {
   if (!data || !data.length) return null
 
   return (
@@ -28,6 +34,13 @@ export default function HistoryChart({ data }: { data: ChartData[] }) {
           <XAxis dataKey="name" />
           <YAxis />
           <Tooltip />
+          {goal && (
+            <ReferenceLine
+              y={goal}
+              stroke="hsl(var(--muted-foreground))"
+              strokeDasharray="3 3"
+            />
+          )}
           <Area type="monotone" dataKey="steps" stroke="hsl(var(--primary))" fillOpacity={1} fill="url(#stepsColor)" />
         </AreaChart>
       </ResponsiveContainer>

--- a/frontend-next/src/hooks/useGarminData.ts
+++ b/frontend-next/src/hooks/useGarminData.ts
@@ -1,7 +1,13 @@
 import { useEffect, useState } from 'react'
 import type { MockData } from './useMockData'
 
-export default function useGarminData() {
+interface Options {
+  historyDays?: number
+  activityLimit?: number
+}
+
+export default function useGarminData(options: Options = {}) {
+  const { historyDays = 7, activityLimit = 1 } = options
   const [data, setData] = useState<MockData | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -9,42 +15,44 @@ export default function useGarminData() {
   useEffect(() => {
     async function load() {
       try {
-        const [summaryRes, weeklyRes, actsRes] = await Promise.all([
+        const [summaryRes, historyRes, actsRes] = await Promise.all([
           fetch('/api/summary'),
-          fetch('/api/weekly'),
-          fetch('/api/activities?limit=1'),
+          fetch(`/api/history?days=${historyDays}`),
+          fetch(`/api/activities?limit=${activityLimit}`),
         ])
 
         if (!summaryRes.ok) throw new Error(await summaryRes.text())
-        if (!weeklyRes.ok) throw new Error(await weeklyRes.text())
+        if (!historyRes.ok) throw new Error(await historyRes.text())
         if (!actsRes.ok) throw new Error(await actsRes.text())
 
         const summary = await summaryRes.json()
-        const weekly: MockData['activities'] = await weeklyRes.json()
+        const history: MockData['activities'] = await historyRes.json()
         const acts = await actsRes.json()
 
         let gps: MockData['gps'] | undefined
         if (Array.isArray(acts) && acts.length) {
-          const routeRes = await fetch(`/api/activity/${acts[0].id}`)
-          if (routeRes.ok) {
-            const points: { lat: number; lon: number }[] = await routeRes.json()
-            gps = {
-              coordinates: points.map(
-                (p) => [p.lat, p.lon] as [number, number]
-              ),
+          const coords: [number, number][] = []
+          for (const act of acts) {
+            const routeRes = await fetch(`/api/activity/${act.id}`)
+            if (routeRes.ok) {
+              const points: { lat: number; lon: number }[] = await routeRes.json()
+              coords.push(
+                ...points.map(p => [p.lat, p.lon] as [number, number])
+              )
             }
           }
+          gps = { coordinates: coords }
         }
 
         setData({
           metrics: summary,
-          activities: weekly,
+          activities: history,
           goals: { steps: 10000, sleep_hours: 8 },
           gps: gps ?? { coordinates: [] },
-          stepsHistory: weekly.map((d) => d.steps),
+          stepsHistory: history.map(d => d.steps),
           hrZones: [],
           sleepStages: [],
-          vo2History: weekly.map((d) => d.vo2max ?? 0),
+          vo2History: history.map(d => d.vo2max ?? 0),
         })
         setError(null)
       } catch (err) {
@@ -54,7 +62,7 @@ export default function useGarminData() {
       }
     }
     load()
-  }, [])
+  }, [historyDays, activityLimit])
 
   return { data, isLoading, error }
 }

--- a/frontend-next/src/pages/index.tsx
+++ b/frontend-next/src/pages/index.tsx
@@ -13,6 +13,7 @@ const MapView = dynamic(() => import('@/components/Dashboard/MapView'), {
 })
 import InsightsChart from '@/components/Dashboard/InsightsChart'
 import ActivitiesTable from '@/components/Dashboard/ActivitiesTable'
+import HistoryTab from '@/components/Dashboard/HistoryTab'
 import Header from '@/components/Header'
 
 export default function HomePage() {
@@ -24,6 +25,7 @@ export default function HomePage() {
           <TabsTrigger value="overview">Overview</TabsTrigger>
           <TabsTrigger value="activities">Activities</TabsTrigger>
           <TabsTrigger value="insights">Insights</TabsTrigger>
+          <TabsTrigger value="history">History</TabsTrigger>
           <TabsTrigger value="goals">Goals</TabsTrigger>
           <TabsTrigger value="map">Map</TabsTrigger>
         </TabsList>
@@ -48,6 +50,9 @@ export default function HomePage() {
         </TabsContent>
         <TabsContent value="insights">
           <InsightsChart />
+        </TabsContent>
+        <TabsContent value="history">
+          <HistoryTab />
         </TabsContent>
         <TabsContent value="goals">
           <GoalsRing />


### PR DESCRIPTION
## Summary
- fetch data from `/api/history` and multiple activities in `useGarminData`
- show heatmaps from several activities
- overlay goals in `HistoryChart`
- add new `HistoryTab` and tab trigger in homepage
- document larger backfill instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882fc14cd8483248c0219a7e0c5439f