### PR TITLE
Handle invalid GPX responses

### DIFF
--- a/api/__tests__/scraper.test.js
+++ b/api/__tests__/scraper.test.js
@@ -98,6 +98,11 @@ describe('fetchActivityRoute', () => {
     expect(points).toEqual([{ lat: 1, lon: 2 }]);
     expect(gcClient.client.get).toHaveBeenCalledWith('gpx/123');
   });
+
+  it('throws on invalid gpx data', async () => {
+    gcClient.client.get.mockResolvedValue('');
+    await expect(fetchActivityRoute('123')).rejects.toThrow('Invalid GPX data');
+  });
 });
 
 describe('fetchRecentActivities', () => {


### PR DESCRIPTION
## Summary
- guard against missing/invalid GPX when fetching an activity
- log raw response and surface parsing errors
- test invalid GPX scenario

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688304c6cc548324a59b30d7636e1057