### PR TITLE
Fix leaflet types

### DIFF
--- a/frontend-next/package.json
+++ b/frontend-next/package.json
@@ -46,6 +46,7 @@
     "@testing-library/dom": "^9.3.2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@types/leaflet": "^1.9.20",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/frontend-next/src/components/Dashboard/MapView.tsx
+++ b/frontend-next/src/components/Dashboard/MapView.tsx
@@ -67,16 +67,12 @@ export default function MapView() {
         </Button>
       </CardHeader>
       <CardContent className="h-64">
-        {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-        {/* @ts-ignore react-leaflet types incompatible with React 19 */}
         <MapContainer center={center} zoom={15} className="h-full w-full">
           <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
           {heat ? (
             <HeatLayer points={coords} />
           ) : (
             <>
-              {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-              {/* @ts-ignore react-leaflet types incompatible with React 19 */}
               <Polyline positions={coords} color="blue" />
             </>
           )}


### PR DESCRIPTION
## Summary
- add `@types/leaflet` to fix missing typings
- remove `@ts-ignore` around `MapContainer` and `Polyline`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68830659432883249ec371b4b4912243