### PR TITLE
Require absolute GARMIN_COOKIE_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ A small dashboard that collects your Garmin activity data. The backend is an Exp
    ```
 
    Set `GARMIN_COOKIE_PATH` to the session file and fill in the InfluxDB
-   options. The path must be absolute (for example
-   `GARMIN_COOKIE_PATH=$HOME/garmin_session.json`) or it will be resolved
-   relative to `api/` when running `npm start`. Change `PORT` if you need a
-   different API port (defaults to `3002`).
+   options. The value **must** be an absolute path, for example
+   `GARMIN_COOKIE_PATH=$HOME/garmin_session.json`. Login will fail if the
+   path is not absolute. Change `PORT` if you need a different API
+   port (defaults to `3002`).
 
 3. **Install dependencies and start the frontend-next app**
 

--- a/api/scraper.js
+++ b/api/scraper.js
@@ -2,6 +2,7 @@
 const { GarminConnect } = require('garmin-connect');
 const { InfluxDB, Point } = require('@influxdata/influxdb-client');
 const fs = require('fs');
+const path = require('path');
 const { XMLParser } = require('fast-xml-parser');
 
 const gcClient = new GarminConnect({ username: '', password: '' });
@@ -9,6 +10,9 @@ const gcClient = new GarminConnect({ username: '', password: '' });
 async function login() {
   if (!process.env.GARMIN_COOKIE_PATH) {
     throw new Error('GARMIN_COOKIE_PATH is required');
+  }
+  if (!path.isAbsolute(process.env.GARMIN_COOKIE_PATH)) {
+    throw new Error('GARMIN_COOKIE_PATH must be an absolute path');
   }
   try {
     await fs.promises.access(process.env.GARMIN_COOKIE_PATH);


### PR DESCRIPTION
## Summary
- enforce GARMIN_COOKIE_PATH being absolute in `api/scraper.js`
- document new requirement when creating `.env`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68835f0de50083249d3d8bda95b3655f