### PR TITLE
Add health route and login check

### DIFF
--- a/api/__tests__/index.test.js
+++ b/api/__tests__/index.test.js
@@ -78,6 +78,14 @@ describe('GET /api/activities', () => {
   });
 });
 
+describe('GET /api/health', () => {
+  it('responds with ok status', async () => {
+    const res = await request(app).get('/api/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});
+
 describe('Unknown routes', () => {
   it('responds with 404', async () => {
     const res = await request(app).get('/does/not/exist');


### PR DESCRIPTION
## Summary
- initialize login when server starts and exit on failure
- add `/api/health` endpoint
- test health endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68836800d8e08324b176bd4ecf6913d2