### PR TITLE
Improve dashboard UX and setup

### DIFF
--- a/frontend-next/src/components/Dashboard/ActivitiesTable.tsx
+++ b/frontend-next/src/components/Dashboard/ActivitiesTable.tsx
@@ -1,8 +1,8 @@
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
-import Spinner from "@/components/Spinner"
-import { Alert, AlertDescription } from "@/components/ui/alert"
-import useMockData from "@/hooks/useMockData"
-import useGarminData from "@/hooks/useGarminData"
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import Spinner from '@/components/Spinner'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import useMockData from '@/hooks/useMockData'
+import useGarminData from '@/hooks/useGarminData'
 
 export default function ActivitiesTable() {
   const useData =
@@ -13,7 +13,10 @@ export default function ActivitiesTable() {
   if (error) {
     return (
       <Alert variant="destructive">
-        <AlertDescription>Failed to load dashboard data</AlertDescription>
+        <AlertDescription>
+          Failed to load dashboard data: {error}. Ensure your Garmin session is
+          valid.
+        </AlertDescription>
       </Alert>
     )
   }
@@ -28,30 +31,49 @@ export default function ActivitiesTable() {
         {data.activities.length === 0 ? (
           <>No activities yet</>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-left text-sm">
-              <thead className="border-b">
-                <tr className="text-muted-foreground">
-                  <th className="py-2 pr-4">Date</th>
-                  <th className="py-2 pr-4">Steps</th>
-                  <th className="py-2 pr-4">Resting HR</th>
-                  <th className="py-2">Sleep</th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.activities.map(entry => (
-                  <tr key={entry.time} className="border-b last:border-b-0">
-                    <td className="py-2 pr-4">
-                      {new Date(entry.time).toLocaleDateString()}
-                    </td>
-                    <td className="py-2 pr-4">{entry.steps}</td>
-                    <td className="py-2 pr-4">{entry.resting_hr}</td>
-                    <td className="py-2">{entry.sleep_hours} hrs</td>
+          <>
+            <div className="hidden sm:block overflow-x-auto">
+              <table className="w-full text-left text-sm">
+                <thead className="border-b">
+                  <tr className="text-muted-foreground">
+                    <th className="py-2 pr-4">Date</th>
+                    <th className="py-2 pr-4">Steps</th>
+                    <th className="py-2 pr-4">Resting HR</th>
+                    <th className="py-2">Sleep</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody>
+                  {data.activities.map((entry) => (
+                    <tr key={entry.time} className="border-b last:border-b-0">
+                      <td className="py-2 pr-4">
+                        {new Date(entry.time).toLocaleDateString()}
+                      </td>
+                      <td className="py-2 pr-4">{entry.steps}</td>
+                      <td className="py-2 pr-4">{entry.resting_hr}</td>
+                      <td className="py-2">{entry.sleep_hours} hrs</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="sm:hidden space-y-2">
+              {data.activities.map((entry) => (
+                <div
+                  key={entry.time}
+                  className="border rounded p-2 text-sm flex flex-col gap-1"
+                >
+                  <div className="font-medium">
+                    {new Date(entry.time).toLocaleDateString()}
+                  </div>
+                  <div className="flex justify-between">
+                    <span>Steps: {entry.steps}</span>
+                    <span>HR: {entry.resting_hr}</span>
+                  </div>
+                  <div>Sleep: {entry.sleep_hours} hrs</div>
+                </div>
+              ))}
+            </div>
+          </>
         )}
       </CardContent>
     </Card>

--- a/frontend-next/src/components/Dashboard/GoalsRing.tsx
+++ b/frontend-next/src/components/Dashboard/GoalsRing.tsx
@@ -1,8 +1,8 @@
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
-import Spinner from "@/components/Spinner"
-import { Alert, AlertDescription } from "@/components/ui/alert"
-import useMockData from "@/hooks/useMockData"
-import useGarminData from "@/hooks/useGarminData"
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import Spinner from '@/components/Spinner'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import useMockData from '@/hooks/useMockData'
+import useGarminData from '@/hooks/useGarminData'
 
 export default function GoalsRing({ goal }: { goal?: number }) {
   const useData =
@@ -13,7 +13,10 @@ export default function GoalsRing({ goal }: { goal?: number }) {
   if (error) {
     return (
       <Alert variant="destructive">
-        <AlertDescription>Failed to load dashboard data</AlertDescription>
+        <AlertDescription>
+          Failed to load dashboard data: {error}. Ensure your Garmin session is
+          valid.
+        </AlertDescription>
       </Alert>
     )
   }

--- a/frontend-next/src/components/Dashboard/HistoryTab.tsx
+++ b/frontend-next/src/components/Dashboard/HistoryTab.tsx
@@ -17,13 +17,16 @@ export default function HistoryTab() {
   if (error) {
     return (
       <Alert variant="destructive">
-        <AlertDescription>Failed to load dashboard data</AlertDescription>
+        <AlertDescription>
+          Failed to load dashboard data: {error}. Ensure your Garmin session is
+          valid.
+        </AlertDescription>
       </Alert>
     )
   }
   if (!data) return null
 
-  const chartData = data.activities.map(entry => ({
+  const chartData = data.activities.map((entry) => ({
     name: new Date(entry.time).toLocaleDateString(),
     steps: entry.steps,
   }))
@@ -39,7 +42,7 @@ export default function HistoryTab() {
             type="number"
             min={1}
             value={days}
-            onChange={e => setDays(Number(e.target.value))}
+            onChange={(e) => setDays(Number(e.target.value))}
             className="w-24"
           />
         </div>

--- a/frontend-next/src/components/Dashboard/InsightsChart.tsx
+++ b/frontend-next/src/components/Dashboard/InsightsChart.tsx
@@ -5,12 +5,12 @@ import {
   YAxis,
   Tooltip,
   ResponsiveContainer,
-} from "recharts"
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
-import Spinner from "@/components/Spinner"
-import { Alert, AlertDescription } from "@/components/ui/alert"
-import useMockData from "@/hooks/useMockData"
-import useGarminData from "@/hooks/useGarminData"
+} from 'recharts'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import Spinner from '@/components/Spinner'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import useMockData from '@/hooks/useMockData'
+import useGarminData from '@/hooks/useGarminData'
 
 export default function InsightsChart() {
   const useData =
@@ -21,7 +21,10 @@ export default function InsightsChart() {
   if (error) {
     return (
       <Alert variant="destructive">
-        <AlertDescription>Failed to load dashboard data</AlertDescription>
+        <AlertDescription>
+          Failed to load dashboard data: {error}. Ensure your Garmin session is
+          valid.
+        </AlertDescription>
       </Alert>
     )
   }
@@ -51,11 +54,19 @@ export default function InsightsChart() {
       <CardContent>
         <div className="w-full h-48">
           <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={chartData} margin={{ top: 10, right: 20, bottom: 0, left: 0 }}>
+            <LineChart
+              data={chartData}
+              margin={{ top: 10, right: 20, bottom: 0, left: 0 }}
+            >
               <XAxis dataKey="name" />
               <YAxis />
               <Tooltip />
-              <Line type="monotone" dataKey="steps" stroke="hsl(var(--primary))" strokeWidth={2} />
+              <Line
+                type="monotone"
+                dataKey="steps"
+                stroke="hsl(var(--primary))"
+                strokeWidth={2}
+              />
             </LineChart>
           </ResponsiveContainer>
         </div>

--- a/frontend-next/src/components/Dashboard/MapView.tsx
+++ b/frontend-next/src/components/Dashboard/MapView.tsx
@@ -38,7 +38,10 @@ export default function MapView() {
   if (error) {
     return (
       <Alert variant="destructive">
-        <AlertDescription>Failed to load dashboard data</AlertDescription>
+        <AlertDescription>
+          Failed to load dashboard data: {error}. Ensure your Garmin session is
+          valid.
+        </AlertDescription>
       </Alert>
     )
   }

--- a/frontend-next/src/components/Dashboard/OverviewCard.tsx
+++ b/frontend-next/src/components/Dashboard/OverviewCard.tsx
@@ -1,8 +1,8 @@
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
-import Spinner from "@/components/Spinner"
-import { Alert, AlertDescription } from "@/components/ui/alert"
-import useMockData from "@/hooks/useMockData"
-import useGarminData from "@/hooks/useGarminData"
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import Spinner from '@/components/Spinner'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import useMockData from '@/hooks/useMockData'
+import useGarminData from '@/hooks/useGarminData'
 
 export default function OverviewCard() {
   const useData =
@@ -13,7 +13,10 @@ export default function OverviewCard() {
   if (error) {
     return (
       <Alert variant="destructive">
-        <AlertDescription>Failed to load dashboard data</AlertDescription>
+        <AlertDescription>
+          Failed to load dashboard data: {error}. Ensure your Garmin session is
+          valid.
+        </AlertDescription>
       </Alert>
     )
   }
@@ -48,25 +51,31 @@ export default function OverviewCard() {
             <span className="font-semibold">Steps:</span> {metrics.steps}
           </li>
           <li>
-            <span className="font-semibold">Resting HR:</span> {metrics.resting_hr}
+            <span className="font-semibold">Resting HR:</span>{' '}
+            {metrics.resting_hr}
           </li>
           <li>
             <span className="font-semibold">VO₂ Max:</span> {metrics.vo2max}
           </li>
           <li>
-            <span className="font-semibold">Sleep:</span> {metrics.sleep_hours} hrs
+            <span className="font-semibold">Sleep:</span> {metrics.sleep_hours}{' '}
+            hrs
           </li>
           <li>
-            <span className="font-semibold">Steps History:</span> {stepsHistory.join(', ')}
+            <span className="font-semibold">Steps History:</span>{' '}
+            {stepsHistory.join(', ')}
           </li>
           <li>
-            <span className="font-semibold">HR Zones:</span> {hrZones.join(', ')}
+            <span className="font-semibold">HR Zones:</span>{' '}
+            {hrZones.join(', ')}
           </li>
           <li>
-            <span className="font-semibold">Sleep Stages:</span> {sleepStages.join(', ')}
+            <span className="font-semibold">Sleep Stages:</span>{' '}
+            {sleepStages.join(', ')}
           </li>
           <li>
-            <span className="font-semibold">VO₂ History:</span> {vo2History.join(', ')}
+            <span className="font-semibold">VO₂ History:</span>{' '}
+            {vo2History.join(', ')}
           </li>
         </ul>
       </CardContent>

--- a/frontend-next/src/components/Header.tsx
+++ b/frontend-next/src/components/Header.tsx
@@ -10,8 +10,14 @@ export default function Header() {
         </span>
         <h1 className="text-xl font-semibold md:text-2xl">Garmin Dashboard</h1>
       </div>
-      <Button variant="ghost" size="icon" aria-label="Settings">
-        <Settings className="size-5" />
+      <Button
+        variant="ghost"
+        size="sm"
+        aria-label="Settings"
+        className="focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 flex items-center gap-2"
+      >
+        <Settings className="size-5" aria-hidden="true" />
+        <span className="sr-only sm:not-sr-only">Settings</span>
       </Button>
     </header>
   )

--- a/frontend-next/src/components/SessionStatus.tsx
+++ b/frontend-next/src/components/SessionStatus.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react'
+
+export default function SessionStatus() {
+  const [message, setMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function check() {
+      try {
+        const res = await fetch('/api/summary')
+        if (!res.ok) throw new Error(await res.text())
+      } catch (err) {
+        setMessage(
+          'Garmin session expired or API unreachable. Run `npm run setup` to refresh your session.'
+        )
+      }
+    }
+    check()
+  }, [])
+
+  if (!message) return null
+
+  return (
+    <div className="rounded-md border border-red-300 bg-red-50 p-2 text-sm text-red-700">
+      {message}
+    </div>
+  )
+}

--- a/frontend-next/src/pages/index.tsx
+++ b/frontend-next/src/pages/index.tsx
@@ -1,9 +1,4 @@
-import {
-  Tabs,
-  TabsList,
-  TabsTrigger,
-  TabsContent,
-} from '@/components/ui/tabs'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import OverviewCard from '@/components/Dashboard/OverviewCard'
 import GoalsRing from '@/components/Dashboard/GoalsRing'
 import dynamic from 'next/dynamic'
@@ -15,11 +10,13 @@ import InsightsChart from '@/components/Dashboard/InsightsChart'
 import ActivitiesTable from '@/components/Dashboard/ActivitiesTable'
 import HistoryTab from '@/components/Dashboard/HistoryTab'
 import Header from '@/components/Header'
+import SessionStatus from '@/components/SessionStatus'
 
 export default function HomePage() {
   return (
     <main className="p-6 md:p-10 max-w-screen-lg mx-auto space-y-6">
       <Header />
+      <SessionStatus />
       <Tabs defaultValue="overview" className="space-y-6">
         <TabsList className="flex flex-wrap gap-2">
           <TabsTrigger value="overview">Overview</TabsTrigger>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "prepare": "husky install",
     "start": "concurrently \"npm start --prefix api\" \"npm run dev --prefix frontend-next\"",
     "lint": "npm run lint --prefix frontend-next",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "setup": "node scripts/setup.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+const fs = require('fs')
+const path = require('path')
+const readline = require('readline')
+const { execSync } = require('child_process')
+
+async function prompt(question) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
+  const answer = await new Promise((res) => rl.question(question, res))
+  rl.close()
+  return answer
+}
+
+;(async () => {
+  const influxUrl =
+    (await prompt('InfluxDB URL [http://localhost:8086]: ')) ||
+    'http://localhost:8086'
+  const influxToken = await prompt('InfluxDB token: ')
+  const influxOrg = await prompt('InfluxDB org: ')
+  const influxBucket = (await prompt('InfluxDB bucket [garmin]: ')) || 'garmin'
+  const port = (await prompt('API port [3002]: ')) || '3002'
+  const cookiePath = await prompt('Path to save Garmin session JSON: ')
+
+  const envData = `INFLUX_URL=${influxUrl}
+INFLUX_TOKEN=${influxToken}
+INFLUX_ORG=${influxOrg}
+INFLUX_BUCKET=${influxBucket}
+PORT=${port}
+GARMIN_COOKIE_PATH=${cookiePath}
+NEXT_PUBLIC_MOCK_MODE=false
+`
+  fs.writeFileSync(path.resolve('.env'), envData)
+  console.log('Environment written to .env')
+
+  try {
+    execSync(`node scripts/save-garmin-session.js "${cookiePath}"`, {
+      stdio: 'inherit',
+    })
+    console.log('Garmin session saved')
+  } catch (err) {
+    console.error(
+      'Failed to save session. Run scripts/save-garmin-session.js manually.',
+      err
+    )
+  }
+})()


### PR DESCRIPTION
## Summary
- add interactive `npm run setup` script to simplify environment configuration
- expose session status warnings on the dashboard
- show additional error details on dashboard components
- add accessible label to settings button
- add responsive mobile layout to activities table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68836b9d474883249c2e10319646b3c9