### PR TITLE
Update env example and docs for Garmin credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,6 @@ INFLUX_ORG=your-org
 INFLUX_BUCKET=garmin
 PORT=3002
 GARMIN_COOKIE_PATH=/path/to/saved/session.json
+GARMIN_EMAIL=you@example.com
+GARMIN_PASSWORD=yourPassword
 NEXT_PUBLIC_MOCK_MODE=false

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ npm install
 npm install --prefix api
 npm install --prefix frontend-next
 
-# copy environment file and save Garmin session
+# copy environment file and add your Garmin credentials
 cp .env.example .env
+# edit GARMIN_EMAIL and GARMIN_PASSWORD in .env
 node scripts/save-garmin-session.js $HOME/garmin_session.json --email you@example.com --password yourPassword
 
 # edit .env to point to the session file and your InfluxDB settings


### PR DESCRIPTION
## Summary
- add placeholder GARMIN_EMAIL and GARMIN_PASSWORD
- document updating these credentials when copying `.env.example`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688435a950d48324b0bb3d4eb0c8b812