### PR TITLE
Add unified data hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ to save the Garmin session file automatically.
 
 Set `NEXT_PUBLIC_MOCK_MODE=true` in `.env` to load metrics from `frontend-next/public/mockData.json` without contacting Garmin.
 
+### Data fetching
+
+All dashboard components use a `useDashboardData` hook which automatically
+switches between live Garmin requests and the bundled mock data based on the
+`NEXT_PUBLIC_MOCK_MODE` variable. Tests can mock this hook to provide stable
+fixtures.
+
 ## Backfill History
 
 Populate InfluxDB with older data using `scripts/backfill-garmin-history.js`:

--- a/frontend-next/src/components/Dashboard/ActivitiesTable.tsx
+++ b/frontend-next/src/components/Dashboard/ActivitiesTable.tsx
@@ -1,13 +1,10 @@
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import Spinner from '@/components/Spinner'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import useMockData from '@/hooks/useMockData'
-import useGarminData from '@/hooks/useGarminData'
+import useDashboardData from '@/hooks/useDashboardData'
 
 export default function ActivitiesTable() {
-  const useData =
-    process.env.NEXT_PUBLIC_MOCK_MODE === 'true' ? useMockData : useGarminData
-  const { data, isLoading, error } = useData()
+  const { data, isLoading, error } = useDashboardData()
 
   if (isLoading) return <Spinner />
   if (error) {

--- a/frontend-next/src/components/Dashboard/GoalsRing.tsx
+++ b/frontend-next/src/components/Dashboard/GoalsRing.tsx
@@ -1,13 +1,10 @@
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import Spinner from '@/components/Spinner'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import useMockData from '@/hooks/useMockData'
-import useGarminData from '@/hooks/useGarminData'
+import useDashboardData from '@/hooks/useDashboardData'
 
 export default function GoalsRing({ goal }: { goal?: number }) {
-  const useData =
-    process.env.NEXT_PUBLIC_MOCK_MODE === 'true' ? useMockData : useGarminData
-  const { data, isLoading, error } = useData()
+  const { data, isLoading, error } = useDashboardData()
 
   if (isLoading) return <Spinner />
   if (error) {

--- a/frontend-next/src/components/Dashboard/HistoryTab.tsx
+++ b/frontend-next/src/components/Dashboard/HistoryTab.tsx
@@ -3,15 +3,12 @@ import HistoryChart from '../HistoryChart'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import Spinner from '@/components/Spinner'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import useMockData from '@/hooks/useMockData'
-import useGarminData from '@/hooks/useGarminData'
+import useDashboardData from '@/hooks/useDashboardData'
 import { Input } from '@/components/ui/input'
 
 export default function HistoryTab() {
   const [days, setDays] = useState(30)
-  const useData =
-    process.env.NEXT_PUBLIC_MOCK_MODE === 'true' ? useMockData : useGarminData
-  const { data, isLoading, error } = useData({ historyDays: days })
+  const { data, isLoading, error } = useDashboardData({ historyDays: days })
 
   if (isLoading) return <Spinner />
   if (error) {

--- a/frontend-next/src/components/Dashboard/InsightsChart.tsx
+++ b/frontend-next/src/components/Dashboard/InsightsChart.tsx
@@ -9,13 +9,10 @@ import {
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import Spinner from '@/components/Spinner'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import useMockData from '@/hooks/useMockData'
-import useGarminData from '@/hooks/useGarminData'
+import useDashboardData from '@/hooks/useDashboardData'
 
 export default function InsightsChart() {
-  const useData =
-    process.env.NEXT_PUBLIC_MOCK_MODE === 'true' ? useMockData : useGarminData
-  const { data, isLoading, error } = useData()
+  const { data, isLoading, error } = useDashboardData()
 
   if (isLoading) return <Spinner />
   if (error) {

--- a/frontend-next/src/components/Dashboard/MapView.tsx
+++ b/frontend-next/src/components/Dashboard/MapView.tsx
@@ -7,8 +7,7 @@ import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import Spinner from '@/components/Spinner'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import useMockData from '@/hooks/useMockData'
-import useGarminData from '@/hooks/useGarminData'
+import useDashboardData from '@/hooks/useDashboardData'
 
 interface HeatProps {
   points: [number, number][]
@@ -29,9 +28,7 @@ function HeatLayer({ points }: HeatProps) {
 }
 
 export default function MapView() {
-  const useData =
-    process.env.NEXT_PUBLIC_MOCK_MODE === 'true' ? useMockData : useGarminData
-  const { data, isLoading, error } = useData({ activityLimit: 5 })
+  const { data, isLoading, error } = useDashboardData({ activityLimit: 5 })
   const [heat, setHeat] = useState(false)
 
   if (isLoading) return <Spinner />

--- a/frontend-next/src/components/Dashboard/OverviewCard.tsx
+++ b/frontend-next/src/components/Dashboard/OverviewCard.tsx
@@ -1,13 +1,10 @@
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import Spinner from '@/components/Spinner'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import useMockData from '@/hooks/useMockData'
-import useGarminData from '@/hooks/useGarminData'
+import useDashboardData from '@/hooks/useDashboardData'
 
 export default function OverviewCard() {
-  const useData =
-    process.env.NEXT_PUBLIC_MOCK_MODE === 'true' ? useMockData : useGarminData
-  const { data, isLoading, error } = useData()
+  const { data, isLoading, error } = useDashboardData()
 
   if (isLoading) return <Spinner />
   if (error) {

--- a/frontend-next/src/components/Dashboard/__tests__/OverviewCard.test.tsx
+++ b/frontend-next/src/components/Dashboard/__tests__/OverviewCard.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { beforeEach, afterEach, jest, test, expect } from '@jest/globals'
-import OverviewCard from '../OverviewCard'
 import mockData from '../../../../public/mockData.json'
+import useDashboardData from '../../../hooks/useDashboardData'
+import OverviewCard from '../OverviewCard'
 
 beforeEach(() => {
   process.env.NEXT_PUBLIC_MOCK_MODE = 'true'

--- a/frontend-next/src/hooks/useDashboardData.ts
+++ b/frontend-next/src/hooks/useDashboardData.ts
@@ -1,0 +1,8 @@
+import useMockData from './useMockData'
+import useGarminData, { type Options } from './useGarminData'
+
+export default function useDashboardData(options: Options = {}) {
+  const isMock = process.env.NEXT_PUBLIC_MOCK_MODE === 'true'
+  const useData = isMock ? useMockData : useGarminData
+  return useData(options)
+}

--- a/frontend-next/src/hooks/useGarminData.ts
+++ b/frontend-next/src/hooks/useGarminData.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import type { MockData } from './useMockData'
 
-interface Options {
+export interface Options {
   historyDays?: number
   activityLimit?: number
 }


### PR DESCRIPTION
## Summary
- introduce `useDashboardData` that delegates to mock or Garmin data hooks
- use the unified hook across dashboard components
- export `Options` type from `useGarminData`
- update OverviewCard test to import the new hook
- document dashboard data fetching in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68843b3e6b448324a810ee90a71a236f