### PR TITLE
Add caching for summary endpoint

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -24,6 +24,12 @@ app.get('/api/health', (req, res) => {
 
 app.get('/api/summary', async (req, res) => {
   try {
+    const cached = cache.get("summary");
+    if (cached) {
+      res.json(cached);
+      return;
+    }
+
     const summary = await fetchGarminSummary();
     cache.set("summary", summary);
     res.json(summary);


### PR DESCRIPTION
## Summary
- add cache lookup to summary route
- export stub config and re-require modules in tests
- verify cached summary usage in tests

## Testing
- `npm test --prefix api`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68844423c3688324ab8bf88e2f360a7a