### PR TITLE
Simplify Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,19 @@
 FROM node:20
 WORKDIR /app
+
+# copy root package files first for better caching
 COPY package*.json ./
-RUN npm install
+# copy package files for api and frontend
+COPY api/package*.json ./api/
+COPY frontend-next/package*.json ./frontend-next/
+
+# install dependencies for all workspaces
+RUN npm install \
+  && npm install --prefix api \
+  && npm install --prefix frontend-next
+
+# copy the rest of the source code
 COPY . .
-CMD ["npm", "run", "dev"]
+
+# default command runs both API and frontend via the root start script
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,7 @@
 version: '3'
 services:
-  api:
+  app:
     build: .
-    command: npm --prefix api start
-    ports:
-      - "3002:3002"
-  frontend:
-    build: .
-    command: npm --prefix frontend-next run dev
     ports:
       - "3000:3000"
+      - "3002:3002"


### PR DESCRIPTION
## Summary
- configure Dockerfile to install both app deps
- run both services via `npm start`
- simplify docker-compose to single service

## Testing
- `npm test`
- `docker compose` build fails due to missing Docker daemon

------
https://chatgpt.com/codex/tasks/task_e_6884463d97148324b0abd31d8332a897