### PR TITLE
Debounce history fetches

### DIFF
--- a/frontend-next/package-lock.json
+++ b/frontend-next/package-lock.json
@@ -31,7 +31,8 @@
         "react-dom": "19.1.0",
         "react-leaflet": "^5.0.0",
         "recharts": "^3.1.0",
-        "tailwind-merge": "^3.3.1"
+        "tailwind-merge": "^3.3.1",
+        "use-debounce": "^10.0.5"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -20163,6 +20164,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.5.tgz",
+      "integrity": "sha512-Q76E3lnIV+4YT9AHcrHEHYmAd9LKwUAbPXDm7FlqVGDHiSOhX3RDjT8dm0AxbJup6WgOb1YEcKyCr11kBJR5KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/use-sidecar": {

--- a/frontend-next/package.json
+++ b/frontend-next/package.json
@@ -35,7 +35,8 @@
     "react-dom": "19.1.0",
     "react-leaflet": "^5.0.0",
     "recharts": "^3.1.0",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "use-debounce": "^10.0.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend-next/src/components/Dashboard/HistoryTab.tsx
+++ b/frontend-next/src/components/Dashboard/HistoryTab.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useDebouncedCallback } from 'use-debounce'
 import HistoryChart from '../HistoryChart'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import Spinner from '@/components/Spinner'
@@ -8,6 +9,9 @@ import { Input } from '@/components/ui/input'
 
 export default function HistoryTab() {
   const [days, setDays] = useState(30)
+  const setDaysDebounced = useDebouncedCallback((value: number) => {
+    setDays(value)
+  }, 300)
   const { data, isLoading, error } = useDashboardData({ historyDays: days })
 
   if (isLoading) return <Spinner />
@@ -39,7 +43,7 @@ export default function HistoryTab() {
             type="number"
             min={1}
             value={days}
-            onChange={(e) => setDays(Number(e.target.value))}
+            onChange={(e) => setDaysDebounced(Number(e.target.value))}
             className="w-24"
           />
         </div>

--- a/frontend-next/src/components/Dashboard/__tests__/HistoryTab.test.tsx
+++ b/frontend-next/src/components/Dashboard/__tests__/HistoryTab.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
+import HistoryTab from '../HistoryTab'
+import '@testing-library/jest-dom'
+import { beforeEach, afterEach, jest, test, expect } from '@jest/globals'
+
+beforeEach(() => {
+  jest.useFakeTimers()
+  const fetchMock = jest.fn((url: string) => {
+    const body = url.includes('history') ? [] : {}
+    return Promise.resolve({
+      ok: true,
+      json: async () => body,
+    } as Response)
+  }) as jest.MockedFunction<typeof fetch>
+  global.fetch = fetchMock
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+  ;(global.fetch as jest.Mock).mockClear()
+})
+
+test('debounces data fetches when days change rapidly', async () => {
+  render(<HistoryTab />)
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3))
+  const input = await screen.findByRole('spinbutton')
+
+  await act(async () => {
+    fireEvent.change(input, { target: { value: '5' } })
+    fireEvent.change(input, { target: { value: '10' } })
+  })
+
+  expect(global.fetch).toHaveBeenCalledTimes(3)
+
+  await act(async () => {
+    jest.advanceTimersByTime(300)
+  })
+
+  await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(6))
+})


### PR DESCRIPTION
## Summary
- install `use-debounce` and use it in HistoryTab
- debounce history input changes by 300ms
- add test ensuring rapid changes trigger a single fetch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688448627a208324a6e22840dbebcef4