### PR TITLE
Fix tests mocking

### DIFF
--- a/api/__tests__/scraper.test.js
+++ b/api/__tests__/scraper.test.js
@@ -71,6 +71,9 @@ describe('fetchGarminSummary', () => {
 
 describe('fetchActivityRoute', () => {
   beforeEach(async () => {
+    jest.resetModules();
+    ({ fetchActivityRoute } = require('../scraper.ts'));
+    ({ instance: gcClient } = require('garmin-connect'));
     const fs = require('fs');
     const path = require('path');
     const cookiePath = path.join(__dirname, 'session.json');
@@ -107,6 +110,9 @@ describe('fetchActivityRoute', () => {
 
 describe('fetchRecentActivities', () => {
   beforeEach(async () => {
+    jest.resetModules();
+    ({ fetchRecentActivities } = require('../scraper.ts'));
+    ({ instance: gcClient } = require('garmin-connect'));
     const fs = require('fs');
     const path = require('path');
     const cookiePath = path.join(__dirname, 'session.json');


### PR DESCRIPTION
## Summary
- use fresh Garmin Connect mock in test suite

## Testing
- `npm install --prefix api`
- `npm install --prefix frontend-next`
- `npm test --silent --prefix api __tests__/scraper.test.js` *(fails: 9 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6884504ed448832496115f44b4d3d3cf