### PR TITLE
Add days query validation

### DIFF
--- a/api/__tests__/index.test.js
+++ b/api/__tests__/index.test.js
@@ -75,6 +75,26 @@ describe('GET /api/history', () => {
     expect(res.body).toEqual([{ time: '2024-01-01', steps: 1 }]);
     expect(fetchHistory).toHaveBeenCalledWith(30);
   });
+
+  it('defaults to 7 days when parameter is missing', async () => {
+    fetchHistory.mockResolvedValue([{ time: '2024-01-01', steps: 1 }]);
+    const res = await request(app).get('/api/history');
+    expect(res.status).toBe(200);
+    expect(fetchHistory).toHaveBeenCalledWith(7);
+  });
+
+  it('returns 400 when days parameter is invalid', async () => {
+    const res = await request(app).get('/api/history?days=-5');
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Invalid days parameter' });
+    expect(fetchHistory).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when days parameter exceeds maximum', async () => {
+    const res = await request(app).get('/api/history?days=4000');
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Invalid days parameter' });
+  });
 });
 
 describe('GET /api/activity/:id', () => {

--- a/api/index.ts
+++ b/api/index.ts
@@ -58,7 +58,14 @@ app.get('/api/weekly', async (req, res) => {
 });
 
 app.get('/api/history', async (req, res) => {
-  const days = parseInt(req.query.days) || 7;
+  let days = 7;
+  if (req.query.days !== undefined) {
+    days = Number(req.query.days);
+    if (!Number.isInteger(days) || days <= 0 || days > 3650) {
+      res.status(400).json({ error: 'Invalid days parameter' });
+      return;
+    }
+  }
   try {
     const data = await fetchHistory(days);
     res.json(data);


### PR DESCRIPTION
## Summary
- validate `days` query parameter in history endpoint
- test history endpoint with default value and invalid cases

## Testing
- `npm test` *(fails: Jest encountered syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68845c7ae1888324906bc5292add5d5f