### PR TITLE
Add frontend RTL tests

### DIFF
--- a/frontend-next/src/components/Dashboard/__tests__/ActivitiesTable.test.tsx
+++ b/frontend-next/src/components/Dashboard/__tests__/ActivitiesTable.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import ActivitiesTable from '../ActivitiesTable'
+import useDashboardData from '../../../hooks/useDashboardData'
+
+jest.mock('../../../hooks/useDashboardData')
+
+const mockUseDashboardData = useDashboardData as jest.MockedFunction<
+  typeof useDashboardData
+>
+
+const baseData = {
+  metrics: { steps: 0 },
+  goals: { steps: 10000 },
+  activities: [
+    {
+      time: '2024-05-01T00:00:00Z',
+      steps: 1000,
+      resting_hr: 60,
+      vo2max: 50,
+      sleep_hours: 7,
+    },
+  ],
+  gps: { coordinates: [] },
+  stepsHistory: [],
+  hrZones: [],
+  sleepStages: [],
+  vo2History: [],
+}
+
+describe('ActivitiesTable', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('shows message when no activities', () => {
+    mockUseDashboardData.mockReturnValue({
+      data: { ...baseData, activities: [] },
+      isLoading: false,
+      error: null,
+    })
+    render(<ActivitiesTable />)
+    expect(screen.getByText(/no activities yet/i)).toBeInTheDocument()
+  })
+
+  test('renders table rows for activities', () => {
+    mockUseDashboardData.mockReturnValue({
+      data: baseData,
+      isLoading: false,
+      error: null,
+    })
+    render(<ActivitiesTable />)
+    expect(screen.getByText('1000')).toBeInTheDocument()
+    expect(screen.getByText('HR: 60', { exact: false })).toBeInTheDocument()
+  })
+})

--- a/frontend-next/src/components/Dashboard/__tests__/GoalsRing.test.tsx
+++ b/frontend-next/src/components/Dashboard/__tests__/GoalsRing.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react'
+import GoalsRing from '../GoalsRing'
+import useDashboardData from '../../../hooks/useDashboardData'
+
+jest.mock('../../../hooks/useDashboardData')
+
+const mockUseDashboardData = useDashboardData as jest.MockedFunction<
+  typeof useDashboardData
+>
+
+const baseData = {
+  metrics: { steps: 5000 },
+  goals: { steps: 10000 },
+  activities: [],
+  gps: { coordinates: [] },
+  stepsHistory: [],
+  hrZones: [],
+  sleepStages: [],
+  vo2History: [],
+}
+
+describe('GoalsRing', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('shows percentage of goal achieved', () => {
+    mockUseDashboardData.mockReturnValue({
+      data: baseData,
+      isLoading: false,
+      error: null,
+    })
+    render(<GoalsRing />)
+    expect(screen.getByText('50%')).toBeInTheDocument()
+  })
+
+  test('renders loading state', () => {
+    mockUseDashboardData.mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+    })
+    const { container } = render(<GoalsRing />)
+    expect(container.querySelector('svg')).toBeTruthy()
+  })
+
+  test('renders error state', () => {
+    mockUseDashboardData.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: 'oops',
+    })
+    render(<GoalsRing />)
+    expect(
+      screen.getByText(/failed to load dashboard data/i)
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend-next/src/hooks/__tests__/useDashboardData.test.ts
+++ b/frontend-next/src/hooks/__tests__/useDashboardData.test.ts
@@ -1,0 +1,44 @@
+import { renderHook } from '@testing-library/react'
+import useDashboardData from '../useDashboardData'
+import useMockData from '../useMockData'
+import useGarminData from '../useGarminData'
+
+jest.mock('../useMockData')
+jest.mock('../useGarminData')
+
+const mockUseMockData = useMockData as jest.MockedFunction<typeof useMockData>
+const mockUseGarminData = useGarminData as jest.MockedFunction<
+  typeof useGarminData
+>
+
+describe('useDashboardData', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+    delete process.env.NEXT_PUBLIC_MOCK_MODE
+  })
+
+  test('uses mock data when NEXT_PUBLIC_MOCK_MODE=true', () => {
+    process.env.NEXT_PUBLIC_MOCK_MODE = 'true'
+    mockUseMockData.mockReturnValue({
+      data: 'mock',
+      isLoading: false,
+      error: null,
+    } as any)
+    const { result } = renderHook(() => useDashboardData())
+    expect(result.current.data).toBe('mock')
+    expect(mockUseMockData).toHaveBeenCalled()
+    expect(mockUseGarminData).not.toHaveBeenCalled()
+  })
+
+  test('uses garmin data when NEXT_PUBLIC_MOCK_MODE is not true', () => {
+    mockUseGarminData.mockReturnValue({
+      data: 'live',
+      isLoading: false,
+      error: null,
+    } as any)
+    const { result } = renderHook(() => useDashboardData())
+    expect(result.current.data).toBe('live')
+    expect(mockUseGarminData).toHaveBeenCalled()
+    expect(mockUseMockData).not.toHaveBeenCalled()
+  })
+})

--- a/frontend-next/src/hooks/__tests__/useMockData.test.ts
+++ b/frontend-next/src/hooks/__tests__/useMockData.test.ts
@@ -1,0 +1,22 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import useMockData from '../useMockData'
+import mockData from '../../../public/mockData.json'
+
+beforeEach(() => {
+  const fetchMock = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => mockData,
+  }) as jest.MockedFunction<typeof fetch>
+  global.fetch = fetchMock
+})
+
+afterEach(() => {
+  ;(global.fetch as jest.Mock).mockClear()
+})
+
+test('loads mock data from /mockData.json', async () => {
+  const { result } = renderHook(() => useMockData())
+  await waitFor(() => expect(result.current.isLoading).toBe(false))
+  expect(global.fetch).toHaveBeenCalledWith('/mockData.json')
+  expect(result.current.data).toEqual(mockData)
+})


### PR DESCRIPTION
## Summary
- add tests for GoalsRing and ActivitiesTable components
- cover hooks with tests for useDashboardData and useMockData

## Testing
- `npm test --prefix frontend-next`
- `npm test` *(fails: Jest cannot parse TS files in api tests)*

------
https://chatgpt.com/codex/tasks/task_e_68845e21f05083248e596d8d38bcbd2a