### PR TITLE
Remove broken demo image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A self-hosted dashboard that syncs your Garmin stats to InfluxDB and visualizes them in a Next.js app.
 
-![Dashboard demo](docs/demo.gif)
-
 ## Table of Contents
 
 - [Features](#features)


### PR DESCRIPTION
## Summary
- remove outdated demo.gif image link from README

## Testing
- `npm install`
- `npm install --prefix api`
- `npm install --prefix frontend-next`
- `npm test` *(fails: GET /api/summary › uses cached result on subsequent requests, GET /api/summary › returns 500 on error, GET /api/weekly › responds with weekly data, GET /api/history › responds with history data, GET /api/history › defaults to 7 days when parameter is missing, GET /api/history › returns 400 when days parameter is invalid, GET /api/history › returns 400 when days parameter exceeds maximum, GET /api/activity/:id › responds with route points, GET /api/activities › returns recent activities, GET /api/activities › passes limit query parameter, GET /api/health › responds with ok status, Unknown routes › responds with 404)*


------
https://chatgpt.com/codex/tasks/task_e_68845e1c944c8324af600537822facb3