### PR TITLE
Improve commit lint prefixes

### DIFF
--- a/scripts/commit-msg.js
+++ b/scripts/commit-msg.js
@@ -9,8 +9,23 @@ if (firstLine.length > 60) {
   process.exit(1);
 }
 
-const firstWord = firstLine.split(' ')[0];
-if (/ed$/.test(firstWord)) {
+let subject = firstLine;
+if (firstLine.includes(':')) {
+  subject = firstLine.split(':')[1].trim();
+}
+const firstWord = subject.split(' ')[0].replace(/[^a-zA-Z]/g, '').toLowerCase();
+const nonImperativePrefixes = [
+  'added',
+  'fixed',
+  'updated',
+  'removed',
+  'changed',
+  'improved',
+  'refactored',
+  'corrected',
+  'merged',
+];
+if (nonImperativePrefixes.includes(firstWord)) {
   console.error('Commit message should use the imperative mood.');
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- expand commit message linting logic to disallow common non‑imperative verbs

## Testing
- `npm test` *(fails: Test Suites: 2 failed, 2 total)*

------
https://chatgpt.com/codex/tasks/task_e_6884cebe524c8324b4bbf6592b4cc854