### PR TITLE
Remove user-facing mock data references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,3 @@ PORT=3002
 GARMIN_COOKIE_PATH=/path/to/saved/session.json
 GARMIN_EMAIL=you@example.com
 GARMIN_PASSWORD=yourPassword
-NEXT_PUBLIC_MOCK_MODE=false

--- a/README.md
+++ b/README.md
@@ -77,16 +77,12 @@ Run `npm run setup` for a guided configuration. This script asks for your
 InfluxDB details and where to save the Garmin session. It writes everything to
 `.env` and attempts to store the session for you.
 
-## Mock Mode
+## Mock Mode (tests only)
 
-Set `NEXT_PUBLIC_MOCK_MODE=true` in `.env` to load metrics from `frontend-next/public/mockData.json` without contacting Garmin.
-
-### Data fetching
-
-All dashboard components use a `useDashboardData` hook which automatically
-switches between live Garmin requests and the bundled mock data based on the
-`NEXT_PUBLIC_MOCK_MODE` variable. Tests can mock this hook to provide stable
-fixtures.
+The repository includes a small mock dataset for Jest tests. Setting
+`NEXT_PUBLIC_MOCK_MODE=true` makes the `useDashboardData` hook return this
+static data instead of hitting the Garmin API. You generally will not use this
+flag in day‑to‑day runs, but the tests rely on it to simulate stable results.
 
 ## Backfill History
 

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -22,7 +22,6 @@ INFLUX_ORG=${escapeValue(influxOrg)}
 INFLUX_BUCKET=${escapeValue(influxBucket)}
 PORT=${escapeValue(port)}
 GARMIN_COOKIE_PATH=${escapeValue(cookiePath)}
-NEXT_PUBLIC_MOCK_MODE=false
 `
 }
 


### PR DESCRIPTION
## Summary
- document that mock mode is only meant for tests
- drop `NEXT_PUBLIC_MOCK_MODE` from sample `.env`
- stop setup script from writing the mock-mode variable

## Testing
- `npm install`
- `npm test` *(fails: Test Suites: 2 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6884cf380fa48324af549f28651362a2