### PR TITLE
Add AJO SVG favicon

### DIFF
--- a/frontend-next/public/favicon.svg
+++ b/frontend-next/public/favicon.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <style>
+    /* light mode: white background, black text */
+    rect { fill: #ffffff; }
+    text { fill: #000000; }
+
+    /* dark mode: dark bg, white text */
+    @media (prefers-color-scheme: dark) {
+      rect { fill: #1a1a1a; }
+      text { fill: #ffffff; }
+    }
+  </style>
+
+  <!-- rounded square background -->
+  <rect x="0" y="0" width="128" height="128" rx="16" ry="16"/>
+
+  <!-- centered "AJO" text -->
+  <text
+    x="50%" y="58%"
+    text-anchor="middle"
+    font-family="Inter, sans-serif"
+    font-size="64"
+    font-weight="600"
+    dominant-baseline="middle"
+  >AJO</text>
+</svg>

--- a/frontend-next/src/pages/_document.tsx
+++ b/frontend-next/src/pages/_document.tsx
@@ -1,0 +1,15 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}


### PR DESCRIPTION
## Summary
- add `frontend-next/public/favicon.svg`
- register the favicon in Next.js custom document

## Testing
- `npm test` *(fails: worker process failed to exit)*
- `npm test --prefix frontend-next`

------
https://chatgpt.com/codex/tasks/task_e_6884ef07be3c83248fcb4174cf0c768f