### PR TITLE
Add Node 20 engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Personal Garmin data viewer that stores your stats in InfluxDB and shows them in
 
 ## Quick Start
 
+This project requires **Node.js 20**. If you use `nvm`, run `nvm use` in the
+repository root to activate the version listed in `.nvmrc`.
+
 1. **Clone and install**
 
    ```bash

--- a/api/package.json
+++ b/api/package.json
@@ -31,5 +31,8 @@
   "keywords": [],
   "author": "",
   "license": "MIT",
+  "engines": {
+    "node": "^20"
+  },
   "type": "commonjs"
 }

--- a/frontend-next/package.json
+++ b/frontend-next/package.json
@@ -2,6 +2,9 @@
   "name": "frontend-next",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "^20"
+  },
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "keywords": [],
   "author": "",
   "license": "MIT",
+  "engines": {
+    "node": "^20"
+  },
   "devDependencies": {
     "husky": "^9.1.7",
     "jest": "^29.7.0",


### PR DESCRIPTION
## Summary
- enforce Node 20 in every `package.json`
- document Node 20 requirement with an `.nvmrc` tip

## Testing
- `npm test` *(fails: test suites 2 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6884f1b6e36c8324843bbf5afb32562a