### PR TITLE
Handle setup script in tests

### DIFF
--- a/api/__tests__/setup.test.js
+++ b/api/__tests__/setup.test.js
@@ -1,3 +1,4 @@
+process.env.NODE_ENV = 'test';
 const { buildEnvData } = require('../../scripts/setup.js');
 
 describe('buildEnvData', () => {


### PR DESCRIPTION
## Summary
- skip interactive prompts in setup.js when `NODE_ENV=test`
- ensure tests set `NODE_ENV` so setup doesn't block

## Testing
- `npm test` *(fails: 22 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6884f1bfa7f08324aadc85e2fcd9379e