### PR TITLE
Add dev server scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ repository root to activate the version listed in `.nvmrc`.
 
 Open [http://localhost:3000](http://localhost:3000) in your browser. If your phone is on the same network, visit `http://<your-computer-ip>:3000` to view it there too.
 
+### Development Scripts
+
+Use these helpers to run the parts individually during development:
+
+```bash
+npm run server    # start only the Express API
+npm run web       # start only the Next.js frontend
+npm run dev       # start both concurrently
+```
+
 ## Docker
 Use Docker if you prefer a single command deployment. The compose file builds
 the image and runs both the API and frontend containers. Copy `.env.example`

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "test": "npm test --prefix api && npm test --prefix frontend-next",
     "prepare": "husky install",
     "start": "concurrently \"npm start --prefix api\" \"npm run dev --prefix frontend-next\"",
+    "server": "cd api && npm start",
+    "web": "cd frontend-next && npm run dev",
+    "dev": "concurrently \"npm run server\" \"npm run web\"",
     "lint": "npm run lint --prefix frontend-next",
     "format": "prettier --write .",
     "setup": "node scripts/setup.js"


### PR DESCRIPTION
## Summary
- add server, web and dev scripts to `package.json`
- document the scripts in the README

## Testing
- `npm install`
- `npm test` *(fails: 2 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688508016f2083249f9f731a377f02fc