### PR TITLE
Improve environment setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ repository root to activate the version listed in `.nvmrc`.
    ```bash
    cp .env.example .env
    ```
-   Edit the file to fill in your InfluxDB details.
+   Edit the file and fill in **all** variables. Be sure to set `GARMIN_COOKIE_PATH`, `GARMIN_EMAIL` and `GARMIN_PASSWORD` in addition to your InfluxDB details.
 
 3. **Save your Garmin session**
 
    ```bash
-   node scripts/save-garmin-session.js ~/garmin_session.json --email you@example.com --password yourPassword
+   node scripts/save-garmin-session.js ~/garmin_session.json --email "$GARMIN_EMAIL" --password "$GARMIN_PASSWORD"
    ```
-   Update `GARMIN_COOKIE_PATH` in `.env` to point to the newly created `garmin_session.json`.
+   The command will create the session file. Ensure that `GARMIN_COOKIE_PATH` in `.env` matches the path you use here.
 
 4. **Start the dashboard**
 
@@ -89,7 +89,8 @@ The dashboard will be available on ports `3000` and `3002` as defined in the com
 
 Run `npm run setup` for a guided configuration. This script asks for your
 InfluxDB details and where to save the Garmin session. It writes everything to
-`.env` and attempts to store the session for you.
+`.env` and attempts to store the session for you. Ensure `GARMIN_EMAIL` and
+`GARMIN_PASSWORD` are set in your environment so the session can be created.
 
 ## Mock Mode (tests only)
 

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -82,6 +82,18 @@ async function prompt(question) {
   }
 
   if (!isTest) {
+    const missing = []
+    if (!process.env.GARMIN_EMAIL) missing.push('GARMIN_EMAIL')
+    if (!process.env.GARMIN_PASSWORD) missing.push('GARMIN_PASSWORD')
+    if (missing.length) {
+      console.warn(
+        `Warning: ${missing.join(' and ')} not set. ` +
+          'Session save will fail unless you provide these variables.'
+      )
+    }
+  }
+
+  if (!isTest) {
     try {
       execSync(`node scripts/save-garmin-session.js "${cookiePath}"`, {
         stdio: 'inherit',


### PR DESCRIPTION
## Summary
- clarify `.env` instructions to fill Garmin values
- show how to run `save-garmin-session.js` using env vars
- warn if required vars are missing in `scripts/setup.js`

## Testing
- `npm install`
- `npm test` *(fails: 9 failed, 14 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68850a4f03c08324b9fde293049af558